### PR TITLE
Add YCSB benchmark

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,7 @@ ext {
     guavaVersion = '30.1-jre'
     javaxJsonVersion = '1.1.4'
     kelpieVersion = '1.2.3'
+    resilience4jRetryVersion = '1.7.1'
     slf4jVersion = '1.7.25'
     scalarDbVersion = '3.7.2'
 }
@@ -22,6 +23,7 @@ dependencies {
     implementation group: 'com.scalar-labs', name: 'kelpie', version: "${kelpieVersion}"
     implementation group: 'com.scalar-labs', name: 'scalardb', version: "${scalarDbVersion}"
     implementation group: 'commons-io', name: 'commons-io', version: "${commonsIoVersion}"
+    implementation group: 'io.github.resilience4j', name: 'resilience4j-retry', version: "${resilience4jRetryVersion}"
     implementation group: 'javax.json', name: 'javax.json-api', version: "${javaxJsonVersion}"
     implementation group: 'org.apache.commons', name: 'commons-csv', version: "${commonsCsvVersion}"
     implementation group: 'org.slf4j', name: 'slf4j-log4j12', version: "${slf4jVersion}"

--- a/src/main/java/com/scalar/db/benchmarks/ycsb/LoadRunner.java
+++ b/src/main/java/com/scalar/db/benchmarks/ycsb/LoadRunner.java
@@ -1,0 +1,130 @@
+package com.scalar.db.benchmarks.ycsb;
+
+import static com.scalar.db.benchmarks.ycsb.YcsbCommon.NAMESPACE_PRIMARY;
+import static com.scalar.db.benchmarks.ycsb.YcsbCommon.NAMESPACE_SECONDARY;
+import static com.scalar.db.benchmarks.ycsb.YcsbCommon.getLoadBatchSize;
+import static com.scalar.db.benchmarks.ycsb.YcsbCommon.getLoadConcurrency;
+import static com.scalar.db.benchmarks.ycsb.YcsbCommon.getLoadOverwrite;
+import static com.scalar.db.benchmarks.ycsb.YcsbCommon.getPayloadSize;
+import static com.scalar.db.benchmarks.ycsb.YcsbCommon.getRecordCount;
+import static com.scalar.db.benchmarks.ycsb.YcsbCommon.prepareGet;
+import static com.scalar.db.benchmarks.ycsb.YcsbCommon.preparePut;
+import static com.scalar.db.benchmarks.ycsb.YcsbCommon.randomFastChars;
+
+import com.scalar.db.api.DistributedTransaction;
+import com.scalar.db.api.DistributedTransactionManager;
+import com.scalar.db.api.Get;
+import com.scalar.db.api.Put;
+import com.scalar.db.benchmarks.Common;
+import com.scalar.db.exception.transaction.AbortException;
+import com.scalar.db.exception.transaction.TransactionException;
+import com.scalar.kelpie.config.Config;
+import io.github.resilience4j.retry.Retry;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.stream.IntStream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class LoadRunner {
+  private static final Logger LOGGER = LoggerFactory.getLogger(LoadRunner.class);
+  private final DistributedTransactionManager manager;
+  private final int id;
+  private final int concurrency;
+  private final int recordCount;
+  private final char[] payload;
+  private final int batchSize;
+  private final boolean overwrite;
+
+  public LoadRunner(Config config, int threadId) {
+    this.id = threadId;
+    manager = Common.getTransactionManager(config);
+    concurrency = getLoadConcurrency(config);
+    batchSize = getLoadBatchSize(config);
+    recordCount = getRecordCount(config);
+    payload = new char[getPayloadSize(config)];
+    overwrite = getLoadOverwrite(config);
+  }
+
+  public void run() {
+    run(false);
+  }
+
+  public void runForMultiStorage() {
+    run(true);
+  }
+
+  private void run(boolean forMultiStorage) {
+    int numPerThread = (recordCount + concurrency - 1) / concurrency;
+    int start = numPerThread * id;
+    int end = Math.min(numPerThread * (id + 1), recordCount);
+    IntStream.range(0, (numPerThread + batchSize - 1) / batchSize)
+        .forEach(
+            i -> {
+              int startId = start + batchSize * i;
+              int endId = Math.min(start + batchSize * (i + 1), end);
+              populateWithTx(startId, endId, forMultiStorage);
+            });
+  }
+
+  private void populateWithTx(int startId, int endId, boolean forMultiStorage) {
+    Runnable populate =
+        () -> {
+          DistributedTransaction transaction = null;
+          try {
+            transaction = manager.start();
+            for (int i = startId; i < endId; ++i) {
+              randomFastChars(ThreadLocalRandom.current(), payload);
+              if (forMultiStorage) {
+                putForMultiStorage(transaction, i, new String(payload));
+              } else {
+                putForSingleStorage(transaction, i, new String(payload));
+              }
+            }
+            transaction.commit();
+          } catch (Exception e) {
+            if (transaction != null) {
+              try {
+                transaction.abort();
+              } catch (AbortException ex) {
+                LOGGER.warn("Abort failed", ex);
+              }
+            }
+            LOGGER.warn("Load failed", e);
+            throw new RuntimeException("Load failed", e);
+          }
+        };
+
+    Retry retry = Common.getRetryWithFixedWaitDuration("load");
+    Runnable decorated = Retry.decorateRunnable(retry, populate);
+    try {
+      decorated.run();
+    } catch (Exception e) {
+      LOGGER.error("Load failed repeatedly!");
+      throw e;
+    }
+  }
+
+  private void putForSingleStorage(DistributedTransaction transaction, int userId, String payload)
+      throws TransactionException {
+    if (overwrite) {
+      Get get = prepareGet(userId);
+      transaction.get(get);
+    }
+    Put put = preparePut(userId, payload);
+    transaction.put(put);
+  }
+
+  private void putForMultiStorage(DistributedTransaction transaction, int userId, String payload)
+      throws TransactionException {
+    if (overwrite) {
+      Get primaryGet = prepareGet(NAMESPACE_PRIMARY, userId);
+      Get secondaryGet = prepareGet(NAMESPACE_SECONDARY, userId);
+      transaction.get(primaryGet);
+      transaction.get(secondaryGet);
+    }
+    Put primaryPut = preparePut(NAMESPACE_PRIMARY, userId, payload);
+    Put secondaryPut = preparePut(NAMESPACE_SECONDARY, userId, payload);
+    transaction.put(primaryPut);
+    transaction.put(secondaryPut);
+  }
+}

--- a/src/main/java/com/scalar/db/benchmarks/ycsb/Loader.java
+++ b/src/main/java/com/scalar/db/benchmarks/ycsb/Loader.java
@@ -1,0 +1,47 @@
+package com.scalar.db.benchmarks.ycsb;
+
+import static com.scalar.db.benchmarks.ycsb.YcsbCommon.getLoadConcurrency;
+
+import com.scalar.db.api.DistributedTransactionManager;
+import com.scalar.db.benchmarks.Common;
+import com.scalar.kelpie.config.Config;
+import com.scalar.kelpie.modules.PreProcessor;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.stream.IntStream;
+
+public class Loader extends PreProcessor {
+  private final DistributedTransactionManager manager;
+  private final int concurrency;
+
+  public Loader(Config config) {
+    super(config);
+    manager = Common.getTransactionManager(config);
+    concurrency = getLoadConcurrency(config);
+  }
+
+  @Override
+  public void execute() {
+    ExecutorService executorService = Executors.newCachedThreadPool();
+    List<CompletableFuture<Void>> futures = new ArrayList<>();
+    IntStream.range(0, concurrency)
+        .forEach(
+            i -> {
+              CompletableFuture<Void> future =
+                  CompletableFuture.runAsync(
+                      () -> new LoadRunner(config, i).run(), executorService);
+              futures.add(future);
+            });
+
+    CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).join();
+    logInfo("All records have been inserted");
+  }
+
+  @Override
+  public void close() throws Exception {
+    manager.close();
+  }
+}

--- a/src/main/java/com/scalar/db/benchmarks/ycsb/MultiStorageLoader.java
+++ b/src/main/java/com/scalar/db/benchmarks/ycsb/MultiStorageLoader.java
@@ -1,0 +1,47 @@
+package com.scalar.db.benchmarks.ycsb;
+
+import static com.scalar.db.benchmarks.ycsb.YcsbCommon.getLoadConcurrency;
+
+import com.scalar.db.api.DistributedTransactionManager;
+import com.scalar.db.benchmarks.Common;
+import com.scalar.kelpie.config.Config;
+import com.scalar.kelpie.modules.PreProcessor;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.stream.IntStream;
+
+public class MultiStorageLoader extends PreProcessor {
+  private final DistributedTransactionManager manager;
+  private final int concurrency;
+
+  public MultiStorageLoader(Config config) {
+    super(config);
+    manager = Common.getTransactionManager(config);
+    concurrency = getLoadConcurrency(config);
+  }
+
+  @Override
+  public void execute() {
+    ExecutorService executorService = Executors.newCachedThreadPool();
+    List<CompletableFuture<Void>> futures = new ArrayList<>();
+    IntStream.range(0, concurrency)
+        .forEach(
+            i -> {
+              CompletableFuture<Void> future =
+                  CompletableFuture.runAsync(
+                      () -> new LoadRunner(config, i).runForMultiStorage(), executorService);
+              futures.add(future);
+            });
+
+    CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).join();
+    logInfo("All records have been inserted");
+  }
+
+  @Override
+  public void close() throws Exception {
+    manager.close();
+  }
+}

--- a/src/main/java/com/scalar/db/benchmarks/ycsb/MultiStorageWorkloadC.java
+++ b/src/main/java/com/scalar/db/benchmarks/ycsb/MultiStorageWorkloadC.java
@@ -45,8 +45,6 @@ public class MultiStorageWorkloadC extends TimeBasedProcessor {
     List<Integer> secondaryIds = new ArrayList<>(opsPerTx);
     for (int i = 0; i < opsPerTx; ++i) {
       primaryIds.add(ThreadLocalRandom.current().nextInt(recordCount));
-    }
-    for (int i = 0; i < opsPerTx; ++i) {
       secondaryIds.add(ThreadLocalRandom.current().nextInt(recordCount));
     }
 
@@ -72,8 +70,13 @@ public class MultiStorageWorkloadC extends TimeBasedProcessor {
   }
 
   @Override
-  public void close() throws Exception {
-    manager.close();
+  public void close() {
+    try {
+      manager.close();
+    } catch (Exception e) {
+      logWarn("Failed to close the transaction manager", e);
+    }
+
     setState(
         Json.createObjectBuilder()
             .add("transaction-retry-count", transactionRetryCount.toString())

--- a/src/main/java/com/scalar/db/benchmarks/ycsb/MultiStorageWorkloadC.java
+++ b/src/main/java/com/scalar/db/benchmarks/ycsb/MultiStorageWorkloadC.java
@@ -1,0 +1,82 @@
+package com.scalar.db.benchmarks.ycsb;
+
+import static com.scalar.db.benchmarks.ycsb.YcsbCommon.CONFIG_NAME;
+import static com.scalar.db.benchmarks.ycsb.YcsbCommon.NAMESPACE_PRIMARY;
+import static com.scalar.db.benchmarks.ycsb.YcsbCommon.NAMESPACE_SECONDARY;
+import static com.scalar.db.benchmarks.ycsb.YcsbCommon.OPS_PER_TX;
+import static com.scalar.db.benchmarks.ycsb.YcsbCommon.getRecordCount;
+import static com.scalar.db.benchmarks.ycsb.YcsbCommon.prepareGet;
+
+import com.scalar.db.api.DistributedTransaction;
+import com.scalar.db.api.DistributedTransactionManager;
+import com.scalar.db.benchmarks.Common;
+import com.scalar.db.exception.transaction.CommitConflictException;
+import com.scalar.db.exception.transaction.CrudConflictException;
+import com.scalar.db.exception.transaction.TransactionException;
+import com.scalar.kelpie.config.Config;
+import com.scalar.kelpie.modules.TimeBasedProcessor;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.LongAdder;
+import javax.json.Json;
+
+/**
+ * Multi-storage workload Fe: Same number of read operation for both primary and secondary database.
+ */
+public class MultiStorageWorkloadC extends TimeBasedProcessor {
+  private static final long DEFAULT_OPS_PER_TX = 2; // 2 read operations per database
+  private final DistributedTransactionManager manager;
+  private final int recordCount;
+  private final int opsPerTx;
+
+  private final LongAdder transactionRetryCount = new LongAdder();
+
+  public MultiStorageWorkloadC(Config config) {
+    super(config);
+    this.manager = Common.getTransactionManager(config);
+    this.recordCount = getRecordCount(config);
+    this.opsPerTx = (int) config.getUserLong(CONFIG_NAME, OPS_PER_TX, DEFAULT_OPS_PER_TX);
+  }
+
+  @Override
+  public void executeEach() throws TransactionException {
+    List<Integer> primaryIds = new ArrayList<>(opsPerTx);
+    List<Integer> secondaryIds = new ArrayList<>(opsPerTx);
+    for (int i = 0; i < opsPerTx; ++i) {
+      primaryIds.add(ThreadLocalRandom.current().nextInt(recordCount));
+    }
+    for (int i = 0; i < opsPerTx; ++i) {
+      secondaryIds.add(ThreadLocalRandom.current().nextInt(recordCount));
+    }
+
+    while (true) {
+      DistributedTransaction transaction = manager.start();
+      try {
+        for (int userId : primaryIds) {
+          transaction.get(prepareGet(NAMESPACE_PRIMARY, userId));
+        }
+        for (int userId : secondaryIds) {
+          transaction.get(prepareGet(NAMESPACE_SECONDARY, userId));
+        }
+        transaction.commit();
+        break;
+      } catch (CrudConflictException | CommitConflictException e) {
+        transaction.abort();
+        transactionRetryCount.increment();
+      } catch (Exception e) {
+        transaction.abort();
+        throw e;
+      }
+    }
+  }
+
+  @Override
+  public void close() throws Exception {
+    manager.close();
+    setState(
+        Json.createObjectBuilder()
+            .add("transaction-retry-count", transactionRetryCount.toString())
+            .build());
+  }
+}

--- a/src/main/java/com/scalar/db/benchmarks/ycsb/MultiStorageWorkloadF.java
+++ b/src/main/java/com/scalar/db/benchmarks/ycsb/MultiStorageWorkloadF.java
@@ -54,13 +54,10 @@ public class MultiStorageWorkloadF extends TimeBasedProcessor {
     char[] payload = new char[payloadSize];
     for (int i = 0; i < opsPerTx; ++i) {
       primaryIds.add(ThreadLocalRandom.current().nextInt(recordCount));
+      secondaryIds.add(ThreadLocalRandom.current().nextInt(recordCount));
 
       YcsbCommon.randomFastChars(ThreadLocalRandom.current(), payload);
-      payloads.add(new String(payload));
-    }
-    for (int i = 0; i < opsPerTx; ++i) {
-      secondaryIds.add(ThreadLocalRandom.current().nextInt(recordCount));
-      // use same payload for secondary
+      payloads.add(new String(payload)); // use same payload for primary and secondary
     }
 
     while (true) {
@@ -89,8 +86,13 @@ public class MultiStorageWorkloadF extends TimeBasedProcessor {
   }
 
   @Override
-  public void close() throws Exception {
-    manager.close();
+  public void close() {
+    try {
+      manager.close();
+    } catch (Exception e) {
+      logWarn("Failed to close the transaction manager", e);
+    }
+
     setState(
         Json.createObjectBuilder()
             .add("transaction-retry-count", transactionRetryCount.toString())

--- a/src/main/java/com/scalar/db/benchmarks/ycsb/MultiStorageWorkloadF.java
+++ b/src/main/java/com/scalar/db/benchmarks/ycsb/MultiStorageWorkloadF.java
@@ -1,0 +1,99 @@
+package com.scalar.db.benchmarks.ycsb;
+
+import static com.scalar.db.benchmarks.ycsb.YcsbCommon.CONFIG_NAME;
+import static com.scalar.db.benchmarks.ycsb.YcsbCommon.NAMESPACE_PRIMARY;
+import static com.scalar.db.benchmarks.ycsb.YcsbCommon.NAMESPACE_SECONDARY;
+import static com.scalar.db.benchmarks.ycsb.YcsbCommon.OPS_PER_TX;
+import static com.scalar.db.benchmarks.ycsb.YcsbCommon.getPayloadSize;
+import static com.scalar.db.benchmarks.ycsb.YcsbCommon.getRecordCount;
+import static com.scalar.db.benchmarks.ycsb.YcsbCommon.prepareGet;
+import static com.scalar.db.benchmarks.ycsb.YcsbCommon.preparePut;
+
+import com.scalar.db.api.DistributedTransaction;
+import com.scalar.db.api.DistributedTransactionManager;
+import com.scalar.db.benchmarks.Common;
+import com.scalar.db.exception.transaction.CommitConflictException;
+import com.scalar.db.exception.transaction.CrudConflictException;
+import com.scalar.db.exception.transaction.TransactionException;
+import com.scalar.kelpie.config.Config;
+import com.scalar.kelpie.modules.TimeBasedProcessor;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.LongAdder;
+import javax.json.Json;
+
+/**
+ * Multi-storage workload Fe: Same number of read-modify-write operation for both primary and
+ * secondary database.
+ */
+public class MultiStorageWorkloadF extends TimeBasedProcessor {
+  // one read-modify-write operation (one read and one write for the same record is regarded as one
+  // operation)
+  private static final long DEFAULT_OPS_PER_TX = 1;
+  private final DistributedTransactionManager manager;
+  private final int recordCount;
+  private final int opsPerTx;
+  private final int payloadSize;
+
+  private final LongAdder transactionRetryCount = new LongAdder();
+
+  public MultiStorageWorkloadF(Config config) {
+    super(config);
+    this.manager = Common.getTransactionManager(config);
+    this.recordCount = getRecordCount(config);
+    this.opsPerTx = (int) config.getUserLong(CONFIG_NAME, OPS_PER_TX, DEFAULT_OPS_PER_TX);
+    this.payloadSize = getPayloadSize(config);
+  }
+
+  @Override
+  public void executeEach() throws TransactionException {
+    List<Integer> primaryIds = new ArrayList<>(opsPerTx);
+    List<Integer> secondaryIds = new ArrayList<>(opsPerTx);
+    List<String> payloads = new ArrayList<>(opsPerTx);
+    char[] payload = new char[payloadSize];
+    for (int i = 0; i < opsPerTx; ++i) {
+      primaryIds.add(ThreadLocalRandom.current().nextInt(recordCount));
+
+      YcsbCommon.randomFastChars(ThreadLocalRandom.current(), payload);
+      payloads.add(new String(payload));
+    }
+    for (int i = 0; i < opsPerTx; ++i) {
+      secondaryIds.add(ThreadLocalRandom.current().nextInt(recordCount));
+      // use same payload for secondary
+    }
+
+    while (true) {
+      DistributedTransaction transaction = manager.start();
+      try {
+        for (int i = 0; i < primaryIds.size(); i++) {
+          int userId = primaryIds.get(i);
+          transaction.get(prepareGet(NAMESPACE_PRIMARY, userId));
+          transaction.put(preparePut(NAMESPACE_PRIMARY, userId, payloads.get(i)));
+        }
+        for (int i = 0; i < secondaryIds.size(); i++) {
+          int userId = secondaryIds.get(i);
+          transaction.get(prepareGet(NAMESPACE_SECONDARY, userId));
+          transaction.put(preparePut(NAMESPACE_SECONDARY, userId, payloads.get(i)));
+        }
+        transaction.commit();
+        break;
+      } catch (CrudConflictException | CommitConflictException e) {
+        transaction.abort();
+        transactionRetryCount.increment();
+      } catch (Exception e) {
+        transaction.abort();
+        throw e;
+      }
+    }
+  }
+
+  @Override
+  public void close() throws Exception {
+    manager.close();
+    setState(
+        Json.createObjectBuilder()
+            .add("transaction-retry-count", transactionRetryCount.toString())
+            .build());
+  }
+}

--- a/src/main/java/com/scalar/db/benchmarks/ycsb/WorkloadA.java
+++ b/src/main/java/com/scalar/db/benchmarks/ycsb/WorkloadA.java
@@ -95,8 +95,13 @@ public class WorkloadA extends TimeBasedProcessor {
   }
 
   @Override
-  public void close() throws Exception {
-    manager.close();
+  public void close() {
+    try {
+      manager.close();
+    } catch (Exception e) {
+      logWarn("Failed to close the transaction manager", e);
+    }
+
     setState(
         Json.createObjectBuilder()
             .add("transaction-retry-count", transactionRetryCount.toString())

--- a/src/main/java/com/scalar/db/benchmarks/ycsb/WorkloadA.java
+++ b/src/main/java/com/scalar/db/benchmarks/ycsb/WorkloadA.java
@@ -1,0 +1,105 @@
+package com.scalar.db.benchmarks.ycsb;
+
+import static com.scalar.db.benchmarks.ycsb.YcsbCommon.CONFIG_NAME;
+import static com.scalar.db.benchmarks.ycsb.YcsbCommon.OPS_PER_TX;
+import static com.scalar.db.benchmarks.ycsb.YcsbCommon.getPayloadSize;
+import static com.scalar.db.benchmarks.ycsb.YcsbCommon.getRecordCount;
+import static com.scalar.db.benchmarks.ycsb.YcsbCommon.prepareGet;
+import static com.scalar.db.benchmarks.ycsb.YcsbCommon.preparePut;
+
+import com.scalar.db.api.DistributedTransaction;
+import com.scalar.db.api.DistributedTransactionManager;
+import com.scalar.db.benchmarks.Common;
+import com.scalar.db.exception.transaction.CommitConflictException;
+import com.scalar.db.exception.transaction.CrudConflictException;
+import com.scalar.db.exception.transaction.TransactionException;
+import com.scalar.kelpie.config.Config;
+import com.scalar.kelpie.modules.TimeBasedProcessor;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.LongAdder;
+import javax.json.Json;
+
+/**
+ * Workload A: Update heavy workload. This workload has a mix of 50/50 reads and writes. The writes
+ * can be changed to read-modify-write if "use_read_modify_write" is set to true.
+ */
+public class WorkloadA extends TimeBasedProcessor {
+  private static final long DEFAULT_OPS_PER_TX = 2; // one read operation and one write operation
+  private static final String USE_READ_MODIFY_WRITE = "use_read_modify_write";
+  private final DistributedTransactionManager manager;
+  private final int recordCount;
+  private final int opsPerTx;
+  private final boolean useReadModifyWrite;
+  private final int payloadSize;
+
+  private final LongAdder transactionRetryCount = new LongAdder();
+
+  public WorkloadA(Config config) {
+    super(config);
+    this.manager = Common.getTransactionManager(config);
+    this.recordCount = getRecordCount(config);
+    this.payloadSize = getPayloadSize(config);
+    this.opsPerTx = (int) config.getUserLong(CONFIG_NAME, OPS_PER_TX, DEFAULT_OPS_PER_TX);
+    if (opsPerTx % 2 != 0) {
+      throw new IllegalArgumentException(OPS_PER_TX + " must be a multiple of 2.");
+    }
+    useReadModifyWrite = config.getUserBoolean(CONFIG_NAME, USE_READ_MODIFY_WRITE, false);
+  }
+
+  @Override
+  public void executeEach() throws TransactionException {
+    int readOpsPerTx = opsPerTx / 2;
+    int writeOpsPerTx = opsPerTx / 2;
+
+    List<Integer> readUserIds = new ArrayList<>(readOpsPerTx);
+    for (int i = 0; i < readOpsPerTx; ++i) {
+      readUserIds.add(ThreadLocalRandom.current().nextInt(recordCount));
+    }
+
+    List<Integer> writeUserIds = new ArrayList<>(writeOpsPerTx);
+    List<String> payloads = new ArrayList<>(writeOpsPerTx);
+    char[] payload = new char[payloadSize];
+    for (int i = 0; i < writeOpsPerTx; ++i) {
+      writeUserIds.add(ThreadLocalRandom.current().nextInt(recordCount));
+
+      YcsbCommon.randomFastChars(ThreadLocalRandom.current(), payload);
+      payloads.add(new String(payload));
+    }
+
+    while (true) {
+      DistributedTransaction transaction = manager.start();
+      try {
+        for (Integer readUserId : readUserIds) {
+          transaction.get(prepareGet(readUserId));
+        }
+
+        for (int i = 0; i < writeUserIds.size(); i++) {
+          int writeUserId = writeUserIds.get(i);
+          if (useReadModifyWrite) {
+            transaction.get(prepareGet(writeUserId));
+          }
+          transaction.put(preparePut(writeUserId, payloads.get(i)));
+        }
+        transaction.commit();
+        break;
+      } catch (CrudConflictException | CommitConflictException e) {
+        transaction.abort();
+        transactionRetryCount.increment();
+      } catch (Exception e) {
+        transaction.abort();
+        throw e;
+      }
+    }
+  }
+
+  @Override
+  public void close() throws Exception {
+    manager.close();
+    setState(
+        Json.createObjectBuilder()
+            .add("transaction-retry-count", transactionRetryCount.toString())
+            .build());
+  }
+}

--- a/src/main/java/com/scalar/db/benchmarks/ycsb/WorkloadC.java
+++ b/src/main/java/com/scalar/db/benchmarks/ycsb/WorkloadC.java
@@ -61,8 +61,13 @@ public class WorkloadC extends TimeBasedProcessor {
   }
 
   @Override
-  public void close() throws Exception {
-    manager.close();
+  public void close() {
+    try {
+      manager.close();
+    } catch (Exception e) {
+      logWarn("Failed to close the transaction manager", e);
+    }
+
     setState(
         Json.createObjectBuilder()
             .add("transaction-retry-count", transactionRetryCount.toString())

--- a/src/main/java/com/scalar/db/benchmarks/ycsb/WorkloadC.java
+++ b/src/main/java/com/scalar/db/benchmarks/ycsb/WorkloadC.java
@@ -1,0 +1,71 @@
+package com.scalar.db.benchmarks.ycsb;
+
+import static com.scalar.db.benchmarks.ycsb.YcsbCommon.CONFIG_NAME;
+import static com.scalar.db.benchmarks.ycsb.YcsbCommon.OPS_PER_TX;
+import static com.scalar.db.benchmarks.ycsb.YcsbCommon.getRecordCount;
+import static com.scalar.db.benchmarks.ycsb.YcsbCommon.prepareGet;
+
+import com.scalar.db.api.DistributedTransaction;
+import com.scalar.db.api.DistributedTransactionManager;
+import com.scalar.db.benchmarks.Common;
+import com.scalar.db.exception.transaction.CommitConflictException;
+import com.scalar.db.exception.transaction.CrudConflictException;
+import com.scalar.db.exception.transaction.TransactionException;
+import com.scalar.kelpie.config.Config;
+import com.scalar.kelpie.modules.TimeBasedProcessor;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.LongAdder;
+import javax.json.Json;
+
+/** Workload C: Read only. */
+public class WorkloadC extends TimeBasedProcessor {
+  private static final long DEFAULT_OPS_PER_TX = 2; // two read operations
+  private final DistributedTransactionManager manager;
+  private final int recordCount;
+  private final int opsPerTx;
+
+  private final LongAdder transactionRetryCount = new LongAdder();
+
+  public WorkloadC(Config config) {
+    super(config);
+    this.manager = Common.getTransactionManager(config);
+    this.recordCount = getRecordCount(config);
+    this.opsPerTx = (int) config.getUserLong(CONFIG_NAME, OPS_PER_TX, DEFAULT_OPS_PER_TX);
+  }
+
+  @Override
+  public void executeEach() throws TransactionException {
+    List<Integer> userIds = new ArrayList<>(opsPerTx);
+    for (int i = 0; i < opsPerTx; ++i) {
+      userIds.add(ThreadLocalRandom.current().nextInt(recordCount));
+    }
+
+    while (true) {
+      DistributedTransaction transaction = manager.start();
+      try {
+        for (Integer userId : userIds) {
+          transaction.get(prepareGet(userId));
+        }
+        transaction.commit();
+        break;
+      } catch (CrudConflictException | CommitConflictException e) {
+        transaction.abort();
+        transactionRetryCount.increment();
+      } catch (Exception e) {
+        transaction.abort();
+        throw e;
+      }
+    }
+  }
+
+  @Override
+  public void close() throws Exception {
+    manager.close();
+    setState(
+        Json.createObjectBuilder()
+            .add("transaction-retry-count", transactionRetryCount.toString())
+            .build());
+  }
+}

--- a/src/main/java/com/scalar/db/benchmarks/ycsb/WorkloadF.java
+++ b/src/main/java/com/scalar/db/benchmarks/ycsb/WorkloadF.java
@@ -1,0 +1,84 @@
+package com.scalar.db.benchmarks.ycsb;
+
+import static com.scalar.db.benchmarks.ycsb.YcsbCommon.CONFIG_NAME;
+import static com.scalar.db.benchmarks.ycsb.YcsbCommon.OPS_PER_TX;
+import static com.scalar.db.benchmarks.ycsb.YcsbCommon.getPayloadSize;
+import static com.scalar.db.benchmarks.ycsb.YcsbCommon.getRecordCount;
+import static com.scalar.db.benchmarks.ycsb.YcsbCommon.prepareGet;
+import static com.scalar.db.benchmarks.ycsb.YcsbCommon.preparePut;
+
+import com.scalar.db.api.DistributedTransaction;
+import com.scalar.db.api.DistributedTransactionManager;
+import com.scalar.db.benchmarks.Common;
+import com.scalar.db.exception.transaction.CommitConflictException;
+import com.scalar.db.exception.transaction.CrudConflictException;
+import com.scalar.db.exception.transaction.TransactionException;
+import com.scalar.kelpie.config.Config;
+import com.scalar.kelpie.modules.TimeBasedProcessor;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.LongAdder;
+import javax.json.Json;
+
+/** Workload F: Read-modify-write. */
+public class WorkloadF extends TimeBasedProcessor {
+  // one read-modify-write operation (one read and one write for the same record is regarded as one
+  // operation)
+  private static final long DEFAULT_OPS_PER_TX = 1;
+  private final DistributedTransactionManager manager;
+  private final int recordCount;
+  private final int opsPerTx;
+  private final int payloadSize;
+
+  private final LongAdder transactionRetryCount = new LongAdder();
+
+  public WorkloadF(Config config) {
+    super(config);
+    this.manager = Common.getTransactionManager(config);
+    this.recordCount = getRecordCount(config);
+    this.opsPerTx = (int) config.getUserLong(CONFIG_NAME, OPS_PER_TX, DEFAULT_OPS_PER_TX);
+    this.payloadSize = getPayloadSize(config);
+  }
+
+  @Override
+  public void executeEach() throws TransactionException {
+    List<Integer> userIds = new ArrayList<>(opsPerTx);
+    List<String> payloads = new ArrayList<>(opsPerTx);
+    char[] payload = new char[payloadSize];
+    for (int i = 0; i < opsPerTx; ++i) {
+      userIds.add(ThreadLocalRandom.current().nextInt(recordCount));
+
+      YcsbCommon.randomFastChars(ThreadLocalRandom.current(), payload);
+      payloads.add(new String(payload));
+    }
+
+    while (true) {
+      DistributedTransaction transaction = manager.start();
+      try {
+        for (int i = 0; i < userIds.size(); i++) {
+          int userId = userIds.get(i);
+          transaction.get(prepareGet(userId));
+          transaction.put(preparePut(userId, payloads.get(i)));
+        }
+        transaction.commit();
+        break;
+      } catch (CrudConflictException | CommitConflictException e) {
+        transaction.abort();
+        transactionRetryCount.increment();
+      } catch (Exception e) {
+        transaction.abort();
+        throw e;
+      }
+    }
+  }
+
+  @Override
+  public void close() throws Exception {
+    manager.close();
+    setState(
+        Json.createObjectBuilder()
+            .add("transaction-retry-count", transactionRetryCount.toString())
+            .build());
+  }
+}

--- a/src/main/java/com/scalar/db/benchmarks/ycsb/WorkloadF.java
+++ b/src/main/java/com/scalar/db/benchmarks/ycsb/WorkloadF.java
@@ -74,8 +74,13 @@ public class WorkloadF extends TimeBasedProcessor {
   }
 
   @Override
-  public void close() throws Exception {
-    manager.close();
+  public void close() {
+    try {
+      manager.close();
+    } catch (Exception e) {
+      logWarn("Failed to close the transaction manager", e);
+    }
+
     setState(
         Json.createObjectBuilder()
             .add("transaction-retry-count", transactionRetryCount.toString())

--- a/src/main/java/com/scalar/db/benchmarks/ycsb/YcsbCommon.java
+++ b/src/main/java/com/scalar/db/benchmarks/ycsb/YcsbCommon.java
@@ -1,0 +1,129 @@
+package com.scalar.db.benchmarks.ycsb;
+
+import com.scalar.db.api.Consistency;
+import com.scalar.db.api.Get;
+import com.scalar.db.api.Put;
+import com.scalar.db.io.Key;
+import com.scalar.db.io.TextColumn;
+import com.scalar.kelpie.config.Config;
+import java.util.Random;
+
+public class YcsbCommon {
+  static final long DEFAULT_LOAD_CONCURRENCY = 1;
+  static final long DEFAULT_LOAD_BATCH_SIZE = 1;
+  static final long DEFAULT_RECORD_COUNT = 1000;
+  static final long DEFAULT_PAYLOAD_SIZE = 1000;
+  static final String NAMESPACE = "ycsb";
+  static final String NAMESPACE_PRIMARY = "ycsb_primary"; // for multi-storage mode
+  static final String NAMESPACE_SECONDARY = "ycsb_secondary"; // for multi-storage mode
+  static final String TABLE = "usertable";
+  static final String YCSB_KEY = "ycsb_key";
+  static final String PAYLOAD = "payload";
+  static final String CONFIG_NAME = "ycsb_config";
+  static final String LOAD_CONCURRENCY = "load_concurrency";
+  static final String LOAD_BATCH_SIZE = "load_batch_size";
+  static final String LOAD_OVERWRITE = "load_overwrite";
+  static final String RECORD_COUNT = "record_count";
+  static final String PAYLOAD_SIZE = "payload_size";
+  static final String OPS_PER_TX = "ops_per_tx";
+  private static final int CHAR_START = 32; // [space]
+  private static final int CHAR_STOP = 126; // [~]
+  private static final char[] CHAR_SYMBOLS = new char[1 + CHAR_STOP - CHAR_START];
+
+  static {
+    for (int i = 0; i < CHAR_SYMBOLS.length; i++) {
+      CHAR_SYMBOLS[i] = (char) (CHAR_START + i);
+    }
+  }
+
+  private static final int[] FAST_MASKS = {
+    554189328, // 10000
+    277094664, // 01000
+    138547332, // 00100
+    69273666, // 00010
+    34636833, // 00001
+    346368330, // 01010
+    727373493, // 10101
+    588826161, // 10001
+    935194491, // 11011
+    658099827, // 10011
+  };
+
+  public static Get prepareGet(int key) {
+    return prepareGet(NAMESPACE, TABLE, key);
+  }
+
+  public static Get prepareGet(String namespace, int key) {
+    return prepareGet(namespace, TABLE, key);
+  }
+
+  public static Get prepareGet(String namespace, String table, int key) {
+    return Get.newBuilder()
+        .namespace(namespace)
+        .table(table)
+        .partitionKey(Key.ofInt(YCSB_KEY, key))
+        .consistency(Consistency.LINEARIZABLE)
+        .build();
+  }
+
+  public static Put preparePut(int key, String payload) {
+    return preparePut(NAMESPACE, TABLE, key, payload);
+  }
+
+  public static Put preparePut(String namespace, int key, String payload) {
+    return preparePut(namespace, TABLE, key, payload);
+  }
+
+  public static Put preparePut(String namespace, String table, int key, String payload) {
+    return Put.newBuilder()
+        .namespace(namespace)
+        .table(table)
+        .partitionKey(Key.ofInt(YCSB_KEY, key))
+        .value(TextColumn.of(PAYLOAD, payload))
+        .consistency(Consistency.LINEARIZABLE)
+        .build();
+  }
+
+  public static int getLoadConcurrency(Config config) {
+    return (int) config.getUserLong(CONFIG_NAME, LOAD_CONCURRENCY, DEFAULT_LOAD_CONCURRENCY);
+  }
+
+  public static int getLoadBatchSize(Config config) {
+    return (int) config.getUserLong(CONFIG_NAME, LOAD_BATCH_SIZE, DEFAULT_LOAD_BATCH_SIZE);
+  }
+
+  public static boolean getLoadOverwrite(Config config) {
+    return config.getUserBoolean(CONFIG_NAME, LOAD_OVERWRITE, false);
+  }
+
+  public static int getRecordCount(Config config) {
+    return (int) config.getUserLong(CONFIG_NAME, RECORD_COUNT, DEFAULT_RECORD_COUNT);
+  }
+
+  public static int getPayloadSize(Config config) {
+    return (int) config.getUserLong(CONFIG_NAME, PAYLOAD_SIZE, DEFAULT_PAYLOAD_SIZE);
+  }
+
+  // This method is taken from benchbase.
+  // https://github.com/cmu-db/benchbase/blob/bbe8c1db84ec81c6cdec6fbeca27b24b1b4e6612/src/main/java/com/oltpbenchmark/util/TextGenerator.java#L80
+  public static char[] randomFastChars(Random rng, char[] chars) {
+    // Ok so now the goal of this is to reduce the number of times that we have to
+    // invoke a random number. We'll do this by grabbing a single random int
+    // and then taking different bitmasks
+
+    int num_rounds = chars.length / FAST_MASKS.length;
+    int i = 0;
+    for (int ctr = 0; ctr < num_rounds; ctr++) {
+      int rand = rng.nextInt(10000); // CHAR_SYMBOLS.length);
+      for (int mask : FAST_MASKS) {
+        chars[i++] = CHAR_SYMBOLS[(rand | mask) % CHAR_SYMBOLS.length];
+      }
+    }
+    // Use the old way for the remaining characters
+    // I am doing this because I am too lazy to think of something more clever
+    for (; i < chars.length; i++) {
+      chars[i] = CHAR_SYMBOLS[rng.nextInt(CHAR_SYMBOLS.length)];
+    }
+    return (chars);
+  }
+}

--- a/src/main/java/com/scalar/db/benchmarks/ycsb/YcsbReporter.java
+++ b/src/main/java/com/scalar/db/benchmarks/ycsb/YcsbReporter.java
@@ -1,0 +1,54 @@
+package com.scalar.db.benchmarks.ycsb;
+
+import com.scalar.kelpie.config.Config;
+import com.scalar.kelpie.modules.PostProcessor;
+import com.scalar.kelpie.stats.Stats;
+
+public class YcsbReporter extends PostProcessor {
+
+  public YcsbReporter(Config config) {
+    super(config);
+  }
+
+  @Override
+  public void execute() {
+    Stats stats = getStats();
+    if (stats == null) {
+      return;
+    }
+    logInfo(
+        "==== Statistics Summary ====\n"
+            + "Throughput: "
+            + stats.getThroughput(config.getRunForSec())
+            + " ops\n"
+            + "Succeeded operations: "
+            + stats.getSuccessCount()
+            + "\n"
+            + "Failed operations: "
+            + stats.getFailureCount()
+            + "\n"
+            + "Mean latency: "
+            + stats.getMeanLatency()
+            + " ms\n"
+            + "SD of latency: "
+            + stats.getStandardDeviation()
+            + " ms\n"
+            + "Max latency: "
+            + stats.getMaxLatency()
+            + " ms\n"
+            + "Latency at 50 percentile: "
+            + stats.getLatencyAtPercentile(50.0)
+            + " ms\n"
+            + "Latency at 90 percentile: "
+            + stats.getLatencyAtPercentile(90.0)
+            + " ms\n"
+            + "Latency at 99 percentile: "
+            + stats.getLatencyAtPercentile(99.0)
+            + " ms\n"
+            + "Transaction retry count: "
+            + getPreviousState().getString("transaction-retry-count"));
+  }
+
+  @Override
+  public void close() {}
+}

--- a/ycsb-benchmark-config.toml
+++ b/ycsb-benchmark-config.toml
@@ -1,0 +1,37 @@
+[modules]
+[modules.preprocessor]
+name = "com.scalar.db.benchmarks.ycsb.Loader"
+path = "./build/libs/scalardb-benchmarks-all.jar"
+[modules.processor]
+name = "com.scalar.db.benchmarks.ycsb.WorkloadF"
+path = "./build/libs/scalardb-benchmarks-all.jar"
+[modules.postprocessor]
+name = "com.scalar.db.benchmarks.ycsb.YcsbReporter"
+path = "./build/libs/scalardb-benchmarks-all.jar"
+
+[common]
+concurrency = 4
+run_for_sec = 5
+ramp_for_sec = 5
+
+[stats]
+realtime_report_enabled = true
+
+[ycsb_config]
+ops_per_tx = 1
+record_count = 1000
+load_concurrency = 4
+#load_batch_size = 10
+#load_overwrite = true
+#use_read_modify_write = true
+
+[database_config]
+contact_points = "jdbc:mysql://localhost/"
+#contact_port =
+username = "root"
+password = "mysql"
+storage = "jdbc"
+transaction_manager = "consensus-commit"
+isolation_level = "SERIALIZABLE"
+serializable_strategy = "EXTRA_READ"
+#config_file = "/path/to/scalardb.properties"

--- a/ycsb-multi-storage-benchmark-config.toml
+++ b/ycsb-multi-storage-benchmark-config.toml
@@ -1,0 +1,28 @@
+[modules]
+[modules.preprocessor]
+name = "com.scalar.db.benchmarks.ycsb.MultiStorageLoader"
+path = "./build/libs/scalardb-benchmarks-all.jar"
+[modules.processor]
+name = "com.scalar.db.benchmarks.ycsb.MultiStorageWorkloadF"
+path = "./build/libs/scalardb-benchmarks-all.jar"
+[modules.postprocessor]
+name = "com.scalar.db.benchmarks.ycsb.YcsbReporter"
+path = "./build/libs/scalardb-benchmarks-all.jar"
+
+[common]
+concurrency = 4
+run_for_sec = 5
+ramp_for_sec = 5
+
+[stats]
+realtime_report_enabled = true
+
+[ycsb_config]
+ops_per_tx = 1
+record_count = 1000
+load_concurrency = 4
+#load_batch_size = 10
+#load_overwrite = true
+
+[database_config]
+config_file = "/path/to/multi-storage-scalardb.properties"

--- a/ycsb-multi-storage-schema.json
+++ b/ycsb-multi-storage-schema.json
@@ -1,0 +1,22 @@
+{
+  "ycsb_primary.usertable": {
+    "transaction": true,
+    "partition-key": [
+      "ycsb_key"
+    ],
+    "columns": {
+      "ycsb_key": "INT",
+      "payload": "TEXT"
+    }
+  },
+  "ycsb_secondary.usertable": {
+    "transaction": true,
+    "partition-key": [
+      "ycsb_key"
+    ],
+    "columns": {
+      "ycsb_key": "INT",
+      "payload": "TEXT"
+    }
+  }
+}

--- a/ycsb-schema.json
+++ b/ycsb-schema.json
@@ -1,0 +1,12 @@
+{
+  "ycsb.usertable": {
+    "transaction": true,
+    "partition-key": [
+      "ycsb_key"
+    ],
+    "columns": {
+      "ycsb_key": "INT",
+      "payload": "TEXT"
+    }
+  }
+}


### PR DESCRIPTION
This PR adds the YCSB benchmark including multi-storage mode. Basically, loader and workloads A, C, and F are imported from kelpie-test, but some refactoring is introduced to support multi-storage mode.