### PR TITLE
Improve exceptions and upgrade ScalarDB version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ ext {
     kelpieVersion = '1.2.3'
     resilience4jRetryVersion = '1.7.1'
     slf4jVersion = '1.7.25'
-    scalarDbVersion = '3.7.2'
+    scalarDbVersion = '3.10.1'
 }
 
 dependencies {

--- a/src/main/java/com/scalar/db/benchmarks/tpcc/TpccBench.java
+++ b/src/main/java/com/scalar/db/benchmarks/tpcc/TpccBench.java
@@ -92,12 +92,18 @@ public class TpccBench extends TimeBasedProcessor {
   }
 
   @Override
-  public void executeEach() throws TransactionException {
+  public void executeEach() throws TransactionException, TpccRollbackException {
     TpccTransaction transaction = generateTpccTransaction();
     while (true) {
       try {
         transaction.execute();
         transaction.commit();
+        break;
+      } catch (TpccRollbackException e) {
+        transaction.abort();
+        logDebug(e.getMessage());
+        // do not count the abort since this is application-level one defined in the spec, and we
+        // would like to count the system aborts only.
         break;
       } catch (CrudConflictException | CommitConflictException e) {
         transaction.abort();

--- a/src/main/java/com/scalar/db/benchmarks/tpcc/TpccRollbackException.java
+++ b/src/main/java/com/scalar/db/benchmarks/tpcc/TpccRollbackException.java
@@ -1,0 +1,8 @@
+package com.scalar.db.benchmarks.tpcc;
+
+public class TpccRollbackException extends Exception {
+
+  public TpccRollbackException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/com/scalar/db/benchmarks/tpcc/transaction/DeliveryTransaction.java
+++ b/src/main/java/com/scalar/db/benchmarks/tpcc/transaction/DeliveryTransaction.java
@@ -44,7 +44,9 @@ public class DeliveryTransaction implements TpccTransaction {
       // Get the oldest outstanding new-order
       List<Result> newOrders = transaction.scan(NewOrder.createScan(warehouseId, districtId));
       if (newOrders.size() != 1) {
-        throw new TransactionException("Invalid scan on new-order");
+        throw new IllegalStateException(
+            String.format(
+                "Invalid scan on new-order: warehouse %d, district: %d", warehouseId, districtId));
       }
       int orderId = newOrders.get(0).getValue(NewOrder.KEY_ORDER_ID).get().getAsInt();
 
@@ -54,7 +56,10 @@ public class DeliveryTransaction implements TpccTransaction {
       // Get the customer of the new-order
       Optional<Result> result = transaction.get(Order.createGet(warehouseId, districtId, orderId));
       if (!result.isPresent()) {
-        throw new TransactionException("Order not found");
+        throw new IllegalStateException(
+            String.format(
+                "Order not found: warehouse %d, district: %d, order: %d",
+                warehouseId, districtId, orderId));
       }
       int customerId = result.get().getValue(Order.KEY_CUSTOMER_ID).get().getAsInt();
 
@@ -76,7 +81,10 @@ public class DeliveryTransaction implements TpccTransaction {
       // Update the customer with new balance and delivery count
       result = transaction.get(Customer.createGet(warehouseId, districtId, customerId));
       if (!result.isPresent()) {
-        throw new TransactionException("Customer not found");
+        throw new IllegalStateException(
+            String.format(
+                "Customer not found: warehouse %d, district: %d, customer: %d",
+                warehouseId, districtId, customerId));
       }
       double balance = result.get().getValue(Customer.KEY_BALANCE).get().getAsDouble() + total;
       int deliveryCount = result.get().getValue(Customer.KEY_DELIVERY_CNT).get().getAsInt() + 1;

--- a/src/main/java/com/scalar/db/benchmarks/tpcc/transaction/OrderStatusTransaction.java
+++ b/src/main/java/com/scalar/db/benchmarks/tpcc/transaction/OrderStatusTransaction.java
@@ -34,7 +34,10 @@ public class OrderStatusTransaction implements TpccTransaction {
   private int getOrderIdBySecondaryIndex(DistributedTransaction tx) throws TransactionException {
     List<Result> results = tx.scan(Order.createScan(warehouseId, districtId, customerId));
     if (results.size() < 1) {
-      throw new TransactionException("Invalid scan on order-secondary");
+      throw new IllegalStateException(
+          String.format(
+              "Invalid scan on order-secondary: warehouse %d, district: %d, customer: %d",
+              warehouseId, districtId, customerId));
     }
     results.sort(Order.ORDER_ID_COMPARATOR);
     return results.get(0).getValue(Order.KEY_ID).get().getAsInt();
@@ -43,7 +46,10 @@ public class OrderStatusTransaction implements TpccTransaction {
   private int getOrderIdByTableIndex(DistributedTransaction tx) throws TransactionException {
     List<Result> results = tx.scan(OrderSecondary.createScan(warehouseId, districtId, customerId));
     if (results.size() != 1) {
-      throw new TransactionException("Invalid scan on order-secondary");
+      throw new IllegalStateException(
+          String.format(
+              "Invalid scan on order-secondary: warehouse %d, district: %d, customer: %d",
+              warehouseId, districtId, customerId));
     }
     return results.get(0).getValue(OrderSecondary.KEY_ORDER_ID).get().getAsInt();
   }
@@ -79,7 +85,10 @@ public class OrderStatusTransaction implements TpccTransaction {
     Optional<Result> result =
         transaction.get(Customer.createGet(warehouseId, districtId, customerId));
     if (!result.isPresent()) {
-      throw new TransactionException("Customer not found");
+      throw new IllegalStateException(
+          String.format(
+              "Customer not found: warehouse %d, district: %d, customer: %d",
+              warehouseId, districtId, customerId));
     }
 
     // Find the last order of the customer
@@ -93,7 +102,10 @@ public class OrderStatusTransaction implements TpccTransaction {
     // Get order
     result = transaction.get(Order.createGet(warehouseId, districtId, orderId));
     if (!result.isPresent()) {
-      throw new TransactionException("Order not found");
+      throw new IllegalStateException(
+          String.format(
+              "Order not found: warehouse %d, district: %d, order: %d",
+              warehouseId, districtId, orderId));
     }
 
     // Get order-line

--- a/src/main/java/com/scalar/db/benchmarks/tpcc/transaction/PaymentTransaction.java
+++ b/src/main/java/com/scalar/db/benchmarks/tpcc/transaction/PaymentTransaction.java
@@ -114,7 +114,8 @@ public class PaymentTransaction implements TpccTransaction {
     // Get and update warehouse
     Optional<Result> result = transaction.get(Warehouse.createGet(warehouseId));
     if (!result.isPresent()) {
-      throw new TransactionException("Warehouse not found");
+      throw new IllegalStateException(
+          String.format("Warehouse not found: warehouse: %d", warehouseId));
     }
     final String warehouseName =
         result.get().getValue(Warehouse.KEY_NAME).get().getAsString().get();
@@ -126,7 +127,9 @@ public class PaymentTransaction implements TpccTransaction {
     // Get and update district
     result = transaction.get(District.createGet(warehouseId, districtId));
     if (!result.isPresent()) {
-      throw new TransactionException("District not found");
+      throw new IllegalStateException(
+          String.format(
+              "District not found: warehouse: %d, district: %d", warehouseId, districtId));
     }
     final String districtName = result.get().getValue(District.KEY_NAME).get().getAsString().get();
     final double districtYtd =
@@ -149,7 +152,10 @@ public class PaymentTransaction implements TpccTransaction {
     result =
         transaction.get(Customer.createGet(customerWarehouseId, customerDistrictId, customerId));
     if (!result.isPresent()) {
-      throw new TransactionException("Customer not found");
+      throw new IllegalStateException(
+          String.format(
+              "Customer not found: warehouse: %d, district: %d, customer: %d",
+              warehouseId, districtId, customerId));
     }
     final double balance =
         result.get().getValue(Customer.KEY_BALANCE).get().getAsDouble() + paymentAmount;

--- a/src/main/java/com/scalar/db/benchmarks/tpcc/transaction/StockLevelTransaction.java
+++ b/src/main/java/com/scalar/db/benchmarks/tpcc/transaction/StockLevelTransaction.java
@@ -45,7 +45,9 @@ public class StockLevelTransaction implements TpccTransaction {
     // Get next order ID in the district
     Optional<Result> result = transaction.get(District.createGet(warehouseId, districtId));
     if (!result.isPresent()) {
-      throw new TransactionException("District not found");
+      throw new IllegalStateException(
+          String.format(
+              "District not found: warehouse: %d, district: %d", warehouseId, districtId));
     }
     int orderId = result.get().getValue(District.KEY_NEXT_O_ID).get().getAsInt();
 
@@ -69,7 +71,10 @@ public class StockLevelTransaction implements TpccTransaction {
     for (int itemId : itemSet) {
       Optional<Result> stock = transaction.get(Stock.createGet(warehouseId, itemId));
       if (!stock.isPresent()) {
-        throw new TransactionException("Stock not found");
+        throw new IllegalStateException(
+            String.format(
+                "Stock not found: warehouse: %d, district: %d, item: %d",
+                warehouseId, districtId, itemId));
       }
       int quantity = stock.get().getValue(Stock.KEY_QUANTITY).get().getAsInt();
       if (quantity < threshold) {

--- a/src/main/java/com/scalar/db/benchmarks/tpcc/transaction/TpccTransaction.java
+++ b/src/main/java/com/scalar/db/benchmarks/tpcc/transaction/TpccTransaction.java
@@ -1,10 +1,11 @@
 package com.scalar.db.benchmarks.tpcc.transaction;
 
+import com.scalar.db.benchmarks.tpcc.TpccRollbackException;
 import com.scalar.db.exception.transaction.TransactionException;
 
 public interface TpccTransaction {
 
-  void execute() throws TransactionException;
+  void execute() throws TransactionException, TpccRollbackException;
 
   void commit() throws TransactionException;
 


### PR DESCRIPTION
This PR improves exceptions in the TPC-C benchmark (and upgrades the ScalarDB version). Previously, we used ScalarDB's `TransactionException` for all exceptions in TPC-C, even though it was an application-specific one or just a runtime exception that would not basically happen. Also, ScalarDB does not assume that it is directly used by users. So, this PR changes it and improves the messages with some debug information. Finally, as a result of this change, we can use the latest ScalarDB version, which slightly changed the `TransactionException` interface.