### PR TITLE
Use a shared DistributedTransactionManager instance in YCSB Loader instead of using as many instances as the specified `load_concurrency`

### DIFF
--- a/src/main/java/com/scalar/db/benchmarks/ycsb/LoadRunner.java
+++ b/src/main/java/com/scalar/db/benchmarks/ycsb/LoadRunner.java
@@ -35,9 +35,9 @@ public class LoadRunner {
   private final int batchSize;
   private final boolean overwrite;
 
-  public LoadRunner(Config config, int threadId) {
+  public LoadRunner(Config config, DistributedTransactionManager manager, int threadId) {
     this.id = threadId;
-    manager = Common.getTransactionManager(config);
+    this.manager = manager;
     concurrency = getLoadConcurrency(config);
     batchSize = getLoadBatchSize(config);
     recordCount = getRecordCount(config);

--- a/src/main/java/com/scalar/db/benchmarks/ycsb/Loader.java
+++ b/src/main/java/com/scalar/db/benchmarks/ycsb/Loader.java
@@ -32,7 +32,7 @@ public class Loader extends PreProcessor {
             i -> {
               CompletableFuture<Void> future =
                   CompletableFuture.runAsync(
-                      () -> new LoadRunner(config, i).run(), executorService);
+                      () -> new LoadRunner(config, manager, i).run(), executorService);
               futures.add(future);
             });
 

--- a/src/main/java/com/scalar/db/benchmarks/ycsb/MultiStorageLoader.java
+++ b/src/main/java/com/scalar/db/benchmarks/ycsb/MultiStorageLoader.java
@@ -32,7 +32,7 @@ public class MultiStorageLoader extends PreProcessor {
             i -> {
               CompletableFuture<Void> future =
                   CompletableFuture.runAsync(
-                      () -> new LoadRunner(config, i).runForMultiStorage(), executorService);
+                      () -> new LoadRunner(config, manager, i).runForMultiStorage(), executorService);
               futures.add(future);
             });
 


### PR DESCRIPTION
## Description

Current YCSB Loader uses as many `DistributedTransactionManager` instances as the specified `concurrency`. It might cause an unexpected large number of DB connections.

## Related issues and/or PRs

N/A

## Changes made

- Use a shared DistributedTransactionManager instance in Loader instead of using as many instances as the specified `load_concurrency`

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A