### PR TITLE
Revise benchmarks doc

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -189,11 +189,11 @@ In addition, the following options are available:
 
 ## Common parameters
 
-| Name           | Description                                             | Default |
-|:---------------|:--------------------------------------------------------|:--------|
-| `concurrency`  | Number of threads for benchmarking.                     | 1       |
-| `run_for_sec`  | Duration of benchmark (in seconds).                     | 60      |
-| `ramp_for_sec` | Duration of ramp-up time before benchmark (in seconds). | 0       |
+| Name           | Description                                             | Default   |
+|:---------------|:--------------------------------------------------------|:----------|
+| `concurrency`  | Number of threads for benchmarking.                     | `1`       |
+| `run_for_sec`  | Duration of benchmark (in seconds).                     | `60`      |
+| `ramp_for_sec` | Duration of ramp-up time before benchmark (in seconds). | `0`       |
 
 ## Workload-specific parameters
 
@@ -207,33 +207,33 @@ Select a workload to see its available parameters.
 
 <div id="TPC-C_3" class="tabcontent" markdown="1">
 
-| Name                   | Description                                                                                                                                                           | Default |
-|:-----------------------|:----------------------------------------------------------------------------------------------------------------------------------------------------------------------|:--------|
-| `num_warehouses`       | Number of warehouses (scale factor) for benchmarking.                                                                                                                 | 1       |
-| `load_concurrency`     | Number of threads for loading.                                                                                                                                        | 1       |
-| `load_start_warehouse` | Start ID of loading warehouse. This option can be useful with `--skip-item-load` when loading large-scale data with multiple clients or adding additional warehouses. | 1       |
-| `load_end_warehouse`   | End ID of loading warehouse. You can use either `--num-warehouses` or `--end-warehouse` to specify the number of loading warehouses.                                  | 1       |
-| `skip_item_load`       | Whether or not to skip loading item table.                                                                                                                            | false   |
-| `use_table_index`      | Whether or not to use a generic table-based secondary index instead of ScalarDB's secondary index.                                                                    | false   |
-| `np_only`              | Run benchmark with only new-order and payment transactions (50% each).                                                                                                | false   |
-| `rate_new_order`       | Percentage of new-order transactions. Specify all the rate parameters to use your own mix.                                                                            | N/A     |
-| `rate_payment`         | Percentage of payment transactions. Specify all the rate parameters to use your own mix.                                                                              | N/A     |
-| `rate_order_status`    | Percentage of order-status transactions. Specify all the rate parameters to use your own mix.                                                                         | N/A     |
-| `rate_delivery`        | Percentage of delivery transactions. Specify all the rate parameters to use your own mix.                                                                             | N/A     |
-| `rate_stock_level`     | Percentage of stock-level transactions. Specify all the rate parameters to use your own mix.                                                                          | N/A     |
-| `backoff`              | Sleep time in milliseconds inserted after a transaction is aborted due to a conflict.                                                                                 | 0       |
+| Name                   | Description                                                                                                                                                           | Default   |
+|:-----------------------|:----------------------------------------------------------------------------------------------------------------------------------------------------------------------|:----------|
+| `num_warehouses`       | Number of warehouses (scale factor) for benchmarking.                                                                                                                 | `1`       |
+| `load_concurrency`     | Number of threads for loading.                                                                                                                                        | `1`       |
+| `load_start_warehouse` | Start ID of loading warehouse. This option can be useful with `--skip-item-load` when loading large-scale data with multiple clients or adding additional warehouses. | `1`       |
+| `load_end_warehouse`   | End ID of loading warehouse. You can use either `--num-warehouses` or `--end-warehouse` to specify the number of loading warehouses.                                  | `1`       |
+| `skip_item_load`       | Whether or not to skip loading item table.                                                                                                                            | `false`   |
+| `use_table_index`      | Whether or not to use a generic table-based secondary index instead of ScalarDB's secondary index.                                                                    | `false`   |
+| `np_only`              | Run benchmark with only new-order and payment transactions (50% each).                                                                                                | `false`   |
+| `rate_new_order`       | Percentage of new-order transactions. Specify all the rate parameters to use your own mix.                                                                            | `N/A`     |
+| `rate_payment`         | Percentage of payment transactions. Specify all the rate parameters to use your own mix.                                                                              | `N/A`     |
+| `rate_order_status`    | Percentage of order-status transactions. Specify all the rate parameters to use your own mix.                                                                         | `N/A`     |
+| `rate_delivery`        | Percentage of delivery transactions. Specify all the rate parameters to use your own mix.                                                                             | `N/A`     |
+| `rate_stock_level`     | Percentage of stock-level transactions. Specify all the rate parameters to use your own mix.                                                                          | `N/A`     |
+| `backoff`              | Sleep time in milliseconds inserted after a transaction is aborted due to a conflict.                                                                                 | `0`       |
 
 </div>
 <div id="YCSB_and_multi-storage_YCSB" class="tabcontent" markdown="1">
 
-| Name                    | Description                                                                       | Default                                   |
-|:------------------------|:----------------------------------------------------------------------------------|:------------------------------------------|
-| `load_concurrency`      | Number of threads for loading.                                                    | 1                                         |
-| `load_batch_size`       | Number of put records in a single loading transaction.                            | 1                                         |
-| `load_overwrite`        | Whether or not to overwrite when loading records.                                 | false                                     |
-| `ops_per_tx`            | Number of operations in a single transaction.                                     | 2 (Workload A and C) <br> 1 (Workload F)  |
-| `record_count`          | Number of records in the target table.                                            | 1000                                      |
-| `use_read_modify_write` | Whether or not to use read-modify-writes instead of blind writes in Workload A.   | false[^rmw]                               |
+| Name                    | Description                                                                       | Default                                       |
+|:------------------------|:----------------------------------------------------------------------------------|:----------------------------------------------|
+| `load_concurrency`      | Number of threads for loading.                                                    | `1`                                           |
+| `load_batch_size`       | Number of put records in a single loading transaction.                            | `1`                                           |
+| `load_overwrite`        | Whether or not to overwrite when loading records.                                 | `false`                                       |
+| `ops_per_tx`            | Number of operations in a single transaction.                                     | `2` (Workload A and C) <br> `1` (Workload F)  |
+| `record_count`          | Number of records in the target table.                                            | `1000`                                        |
+| `use_read_modify_write` | Whether or not to use read-modify-writes instead of blind writes in Workload A.   | `false`[^rmw]                                 |
 
 [^rmw]: The default value is `false` for `use_read_modify_write` since Workload A doesn't assume that the transaction reads the original record first. However, if you're using Consensus Commit as the transaction manager, you must set `use_read_modify_write` to `true`. This is because ScalarDB doesn't allow a blind write for an existing record.
 </div>

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,8 +1,8 @@
-# ScalarDB Benchmarks
+# ScalarDB Benchmarking Tools
 
-This tutorial describes how to set up and run benchmarking tools for ScalarDB.
+This tutorial describes how to run benchmarking tools for ScalarDB. Database benchmarking is helpful for evaluating how databases perform against a set of standards.
 
-## Available benchmark workloads
+## Benchmark workloads
 
 - TPC-C
 - YCSB (Workloads A, C, and F)
@@ -18,6 +18,9 @@ This tutorial describes how to set up and run benchmarking tools for ScalarDB.
 - Gradle
 - [Kelpie](https://github.com/scalar-labs/kelpie)
   - Kelpie is a framework for performing end-to-end testing, such as system benchmarking and verification. Get the latest version from [Kelpie Releases](https://github.com/scalar-labs/kelpie), and unzip the archive file.
+- A client to run the benchmarking tools
+- A target database
+  - For a list of databases that ScalarDB supports, see [Supported Databases](https://github.com/scalar-labs/scalardb/blob/master/docs/scalardb-supported-databases.md).
 
 {% capture notice--info %}
 **Note**
@@ -26,14 +29,6 @@ Currently, only JDK 8 can be used when running the benchmarking tools.
 {% endcapture %}
 
 <div class="notice--info">{{ notice--info | markdownify }}</div>
-
-## Set up your environment
-
-The benchmarking tools require the following:
-
-- A client to run the benchmarking tools
-- A target database
-  - For a list of databases that ScalarDB supports, see [Supported Databases](https://github.com/scalar-labs/scalardb/blob/master/docs/scalardb-supported-databases.md).
 
 ## Set up the benchmarking tools
 
@@ -197,7 +192,7 @@ In addition, the following options are available:
 
 ## Workload-specific parameters
 
-Select a workload to see its available parameters.
+Select a benchmark to see its available workload parameters.
 
 <div id="tabset-3">
 <div class="tab">

--- a/docs/README.md
+++ b/docs/README.md
@@ -216,11 +216,11 @@ Select a workload to see its available parameters.
 | `skip_item_load`       | Whether or not to skip loading item table.                                                                                                                            | `false`   |
 | `use_table_index`      | Whether or not to use a generic table-based secondary index instead of ScalarDB's secondary index.                                                                    | `false`   |
 | `np_only`              | Run benchmark with only new-order and payment transactions (50% each).                                                                                                | `false`   |
-| `rate_new_order`       | Percentage of new-order transactions. Specify all the rate parameters to use your own mix.                                                                            | `N/A`     |
-| `rate_payment`         | Percentage of payment transactions. Specify all the rate parameters to use your own mix.                                                                              | `N/A`     |
-| `rate_order_status`    | Percentage of order-status transactions. Specify all the rate parameters to use your own mix.                                                                         | `N/A`     |
-| `rate_delivery`        | Percentage of delivery transactions. Specify all the rate parameters to use your own mix.                                                                             | `N/A`     |
-| `rate_stock_level`     | Percentage of stock-level transactions. Specify all the rate parameters to use your own mix.                                                                          | `N/A`     |
+| `rate_new_order`       | Percentage of new-order transactions. Specify all the rate parameters to use your own mix.                                                                            | N/A       |
+| `rate_payment`         | Percentage of payment transactions. Specify all the rate parameters to use your own mix.                                                                              | N/A       |
+| `rate_order_status`    | Percentage of order-status transactions. Specify all the rate parameters to use your own mix.                                                                         | N/A       |
+| `rate_delivery`        | Percentage of delivery transactions. Specify all the rate parameters to use your own mix.                                                                             | N/A       |
+| `rate_stock_level`     | Percentage of stock-level transactions. Specify all the rate parameters to use your own mix.                                                                          | N/A       |
 | `backoff`              | Sleep time in milliseconds inserted after a transaction is aborted due to a conflict.                                                                                 | `0`       |
 
 </div>
@@ -231,7 +231,7 @@ Select a workload to see its available parameters.
 | `load_concurrency`      | Number of threads for loading.                                                    | `1`                                           |
 | `load_batch_size`       | Number of put records in a single loading transaction.                            | `1`                                           |
 | `load_overwrite`        | Whether or not to overwrite when loading records.                                 | `false`                                       |
-| `ops_per_tx`            | Number of operations in a single transaction.                                     | `2` (Workload A and C) <br> `1` (Workload F)  |
+| `ops_per_tx`            | Number of operations in a single transaction.                                     | `2` (Workloads A and C) <br> `1` (Workload F)  |
 | `record_count`          | Number of records in the target table.                                            | `1000`                                        |
 | `use_read_modify_write` | Whether or not to use read-modify-writes instead of blind writes in Workload A.   | `false`[^rmw]                                 |
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,114 +1,232 @@
 # ScalarDB Benchmarks
 
-This repository contains benchmark programs for ScalarDB.
+This tutorial describes how to set up and run benchmarking tools for ScalarDB.
 
 ## Available workloads
 
 - TPC-C
-- YCSB (Workload A, C, and F)
-- Multi-storage YCSB (Workload C and F)
-  - A YCSB-variant benchmark using a multi-storage environment of ScalarDB.
-  - Workers in multi-storage YCSB execute the same number of read/write operations in two namespaces (`ycsb_primary` and `ycsb_secondary`).
+- Yahoo! Cloud Serving Benchmark (YCSB) (Workloads A, C, and F)
+- Multi-storage YCSB (Workloads C and F)
+  - This YCSB variant is for a multi-storage environment that uses ScalarDB.
+  - Workers in a multi-storage YCSB execute the same number of read and write operations in two namespaces: `ycsb_primary` and `ycsb_secondary`.
 
 ## Prerequisites
 
-- Java (OpenJDK 8 or higher)
+- One of the following Java Development Kits (JDKs):
+  - [Oracle JDK](https://www.oracle.com/java/technologies/downloads/) LTS version 8
+  - [OpenJDK](https://openjdk.org/install/) LTS version 8
 - Gradle
-- Kelpie
+- [Kelpie](https://github.com/scalar-labs/kelpie)
+  - Kelpie is a framework for performing end-to-end testing, such as system benchmarking and verification. Get the latest version from [Kelpie Releases](https://github.com/scalar-labs/kelpie), and unzip the archive file.
 
-The benchmark uses Kelpie, which is a simple yet general framework for performing end-to-end testing such as system benchmarking and verification. Get the latest version of Kelpie from [here](https://github.com/scalar-labs/kelpie) and unzip the archive.
+{% capture notice--info %}
+**Note**
 
-## Usage
+Currently, only JDK 8 can be used when running the benchmarking tools.
+{% endcapture %}
 
-### Set up an environment
+<div class="notice--info">{{ notice--info | markdownify }}</div>
 
-This benchmark requires the followings:
-- A client to execute this benchmark
-- A target database (See [here](https://github.com/scalar-labs/scalardb/blob/master/docs/scalardb-supported-databases.md) for supported databases)
+## Set up your environment
 
-### Build
+The benchmarking tools require the following:
+
+- A client to run the benchmarking tools
+- A target database
+  - For a list of databases that ScalarDB supports, see [Supported Databases](https://github.com/scalar-labs/scalardb/blob/master/docs/scalardb-supported-databases.md).
+
+## Set up the benchmarking tools
+
+The following sections describe how to set up the benchmarking tools.
+
+### Clone the ScalarDB benchmarks repository
+
+Open **Terminal**, then clone the ScalarDB benchmarks repository by running the following command:
 
 ```console
-./gradlew shadowJar
+$ git clone https://github.com/scalar-labs/scalardb-benchmarks
+```
+
+Then, go to the directory that contains the benchmarking files by running the following command:
+
+```console
+$ cd scalardb-benchmarks
+```
+
+### Build the tools
+
+To build the benchmarking tools, run the following command:
+
+```console
+$ ./gradlew shadowJar
 ```
 
 ### Create tables
 
-Before loading initial data, the tables must be defined using [ScalarDB Schema Loader](https://github.com/scalar-labs/scalardb/blob/master/docs/schema-loader.md). Get the latest schema loader [here](https://github.com/scalar-labs/scalardb/releases) and execute it with the workload-specific schema file. For setting ScalarDB properties, see also the related documents [here](https://github.com/scalar-labs/scalardb#docs).
+Before loading the initial data, the tables must be defined by using the [ScalarDB Schema Loader](https://github.com/scalar-labs/scalardb/blob/master/docs/schema-loader.md). To apply the schema, go to the [ScalarDB Releases](https://github.com/scalar-labs/scalardb/releases) page and download the ScalarDB Schema Loader that matches the version of ScalarDB that you are using to the `scalardb-benchmarks` root folder.
 
-For example, execute the following command with `tpcc-schema.json` to create tables for TPC-C benchmark.
-For YCSB and multi-storage YCSB, use `ycsb-schema.json` and `ycsb-multi-storage-schema.json`, respectively.
+In addition, you need a properties file that contains database configurations for ScalarDB. For details about configuring the ScalarDB properties file, see [ScalarDB Configurations](https://github.com/scalar-labs/scalardb/blob/master/docs/configurations.md).
+
+After applying the schema and configuring the properties file, select a benchmark and follow the instructions to create the tables.
+
+<div id="tabset-1">
+<div class="tab">
+  <button class="tablinks" onclick="openTab(event, 'TPC-C_1', 'tabset-1')" id="defaultOpen-1">TPC-C</button>
+  <button class="tablinks" onclick="openTab(event, 'YCSB_1', 'tabset-1')">YCSB</button>
+  <button class="tablinks" onclick="openTab(event, 'multi-storage_YCSB_1', 'tabset-1')">Multi-storage YCSB</button>
+</div>
+
+<div id="TPC-C_1" class="tabcontent" markdown="1">
+
+To create tables for TPC-C benchmarking ([`tpcc-schema.json`](https://github.com/scalar-labs/scalardb-benchmarks/blob/master/tpcc-schema.json)), run the following command, replacing the contents in the angle brackets as described:
 
 ```console
-java -jar scalardb-schema-loader-<version>.jar --config /path/to/scalardb.properties -f tpcc-schema.json --coordinator
+$ java -jar scalardb-schema-loader-<VERSION>.jar --config /<PATH_TO>/scalardb.properties -f tpcc-schema.json --coordinator
+```
+</div>
+<div id="YCSB_1" class="tabcontent" markdown="1">
+
+To create tables for YCSB benchmarking ([`ycsb-schema.json`](https://github.com/scalar-labs/scalardb-benchmarks/blob/master/ycsb-schema.json)), run the following command, replacing the contents in the angle brackets as described:
+
+```console
+$ java -jar scalardb-schema-loader-<VERSION>.jar --config /<PATH_TO>/scalardb.properties -f ycsb-schema.json --coordinator
+```
+</div>
+<div id="multi-storage_YCSB_1" class="tabcontent" markdown="1">
+
+To create tables for multi-storage YCSB benchmarking ([`ycsb-multi-storage-schema.json`](https://github.com/scalar-labs/scalardb-benchmarks/blob/master/ycsb-multi-storage-schema.json)), run the following command, replacing the contents in the angle brackets as described:
+
+```console
+$ java -jar scalardb-schema-loader-<VERSION>.jar --config /<PATH_TO>/scalardb.properties -f ycsb-multi-storage-schema.json --coordinator
+```
+</div>
+</div>
+
+### Prepare a benchmarking configuration file
+
+To run a benchmark, you must first prepare a benchmarking configuration file. The configuration file requires at least the locations of the workload modules to run and the database configuration. 
+
+The following is an example configuration for running the TPC-C benchmark. The configurations under `database_config` should match the [benchmarking environment that you previously set up](#set-up-your-environment).
+
+{% capture notice--info %}
+**Note**
+
+Alternatively, instead of specifying each database configuration item in the `.toml` file, you can use the ScalarDB properties file. If `config_file` is specified (commented out below), all other configurations under `database_config` will be ignored.
+{% endcapture %}
+
+<div class="notice--info">{{ notice--info | markdownify }}</div>
+
+```toml
+[modules]
+[modules.preprocessor]
+name = "com.scalar.db.benchmarks.tpcc.TpccLoader"
+path = "./build/libs/scalardb-benchmarks-all.jar"
+[modules.processor]
+name = "com.scalar.db.benchmarks.tpcc.TpccBench"
+path = "./build/libs/scalardb-benchmarks-all.jar"
+[modules.postprocessor]
+name = "com.scalar.db.benchmarks.tpcc.TpccReporter"
+path = "./build/libs/scalardb-benchmarks-all.jar"
+
+[database_config]
+contact_points = "localhost"
+contact_port = 9042
+username = "cassandra"
+password = "cassandra"
+storage = "cassandra"
+#config_file = "/<PATH_TO>/scalardb.properties"
 ```
 
-### Load and run
+You can define static parameters to pass to modules in the configuration file. For details, see the sample configuration files below and available parameters in [Common parameters](#common-parameters):
 
-1. Prepare a configuration file
-    - A configuration file requires at least the locations of workload modules to run and the database configuration. The following example shows the case for running TPC-C benchmark. The database configuration should be matched with the benchmark environment set up above. You can use the ScalarDB property file instead of specifying each configuration item. If the `config_file` is specified, all other configuration items will be ignored.
-      ```
-      [modules]
-      [modules.preprocessor]
-      name = "com.scalar.db.benchmarks.tpcc.TpccLoader"
-      path = "./build/libs/scalardb-benchmarks-all.jar"
-      [modules.processor]
-      name = "com.scalar.db.benchmarks.tpcc.TpccBench"
-      path = "./build/libs/scalardb-benchmarks-all.jar"
-      [modules.postprocessor]
-      name = "com.scalar.db.benchmarks.tpcc.TpccReporter"
-      path = "./build/libs/scalardb-benchmarks-all.jar"
- 
-      [database_config]
-      contact_points = "localhost"
-      contact_port = 9042
-      username = "cassandra"
-      password = "cassandra"
-      storage = "cassandra"
-      #config_file = "/path/to/scalardb.properties"
-      ```
-    - You can define static parameters to pass to modules in the file. For details, see the sample configuration files below and available parameters in [the following section](#common-parameters).
-      - TPC-C: `tpcc-benchmark-config.toml`
-      - YCSB: `ycsb-benchmark-config.toml`
-      - Multi-storage YCSB: `ycsb-multi-storage-benchmark-config.toml`
-2. Run a benchmark
-   ```
-   ${kelpie}/bin/kelpie --config your_config.toml
-   ```
-    - `${kelpie}` is a Kelpie directory, which is extracted from the archive you downloaded [above](#prerequisites).
-    - There are other options such as `--only-pre` (i.e., loading data) and `--only-process` (i.e., running benchmark), which run only the specified process. `--except-pre` and `--except-process` run a job without the specified process.
+- **TPC-C:** [`tpcc-benchmark-config.toml`](https://github.com/scalar-labs/scalardb-benchmarks/blob/master/tpcc-benchmark-config.toml)
+- **YCSB:** [`ycsb-benchmark-config.toml`](https://github.com/scalar-labs/scalardb-benchmarks/blob/master/ycsb-benchmark-config.toml)
+- **Multi-storage YCSB:** [`ycsb-multi-storage-benchmark-config.toml`](https://github.com/scalar-labs/scalardb-benchmarks/blob/master/ycsb-multi-storage-benchmark-config.toml)
+
+## Run a benchmark
+
+Select a benchmark, and follow the instructions to run the benchmark.
+
+<div id="tabset-2">
+<div class="tab">
+  <button class="tablinks" onclick="openTab(event, 'TPC-C_2', 'tabset-2')" id="defaultOpen-2">TPC-C</button>
+  <button class="tablinks" onclick="openTab(event, 'YCSB_2', 'tabset-2')">YCSB</button>
+  <button class="tablinks" onclick="openTab(event, 'multi-storage_YCSB_2', 'tabset-2')">Multi-storage YCSB</button>
+</div>
+
+<div id="TPC-C_2" class="tabcontent" markdown="1">
+
+To run the TPC-C benchmark, run the following command, replacing `<PATH_TO_KELPIE>` with the path to the Kelpie directory:
+
+```console
+$ /<PATH_TO_KELPIE>/bin/kelpie --config tpcc-benchmark-config.toml
+```
+</div>
+<div id="YCSB_2" class="tabcontent" markdown="1">
+
+To run the YCSB benchmark, run the following command, replacing `<PATH_TO_KELPIE>` with the path to the Kelpie directory:
+
+```console
+$ /<PATH_TO_KELPIE>/bin/kelpie --config ycsb-benchmark-config.toml
+```
+</div>
+<div id="multi-storage_YCSB_2" class="tabcontent" markdown="1">
+
+To run the multi-storage YCSB benchmark, run the following command, replacing `<PATH_TO_KELPIE>` with the path to the Kelpie directory:
+
+```console
+$ /<PATH_TO_KELPIE>/bin/kelpie --config ycsb-multi-storage-benchmark-config.toml
+```
+</div>
+</div>
+
+In addition, the following options are available:
+
+- `--only-pre`. Only loads the data.
+- `--only-process`. Only runs the benchmark.
+- `--except-pre` Runs a job without loading the data.
+- `--except-process`. Runs a job without running the benchmark.
 
 ## Common parameters
 
-| name           | description                                             | default |
+| Name           | Description                                             | Default |
 |:---------------|:--------------------------------------------------------|:--------|
 | `concurrency`  | Number of threads for benchmarking.                     | 1       |
 | `run_for_sec`  | Duration of benchmark (in seconds).                     | 60      |
-| `ramp_for_sec` | Duration of ramp up time before benchmark (in seconds). | 0       |
+| `ramp_for_sec` | Duration of ramp-up time before benchmark (in seconds). | 0       |
 
 ## Workload-specific parameters
 
-### TPC-C
+Select a workload to see its available parameters.
 
-| name                   | description                                                                                                                                                           | default |
+<div id="tabset-3">
+<div class="tab">
+  <button class="tablinks" onclick="openTab(event, 'TPC-C_3', 'tabset-3')" id="defaultOpen-3">TPC-C</button>
+  <button class="tablinks" onclick="openTab(event, 'YCSB_and_multi-storage_YCSB', 'tabset-3')">YCSB and multi-storage YCSB</button>
+</div>
+
+<div id="TPC-C_3" class="tabcontent" markdown="1">
+
+| Name                   | Description                                                                                                                                                           | Default |
 |:-----------------------|:----------------------------------------------------------------------------------------------------------------------------------------------------------------------|:--------|
 | `num_warehouses`       | Number of warehouses (scale factor) for benchmarking.                                                                                                                 | 1       |
 | `load_concurrency`     | Number of threads for loading.                                                                                                                                        | 1       |
-| `load_start_warehouse` | Start ID of loading warehouse. This option can be useful with `--skip-item-load` when loading large scale data with multiple clients or adding additional warehouses. | 1       |
+| `load_start_warehouse` | Start ID of loading warehouse. This option can be useful with `--skip-item-load` when loading large-scale data with multiple clients or adding additional warehouses. | 1       |
 | `load_end_warehouse`   | End ID of loading warehouse. You can use either `--num-warehouses` or `--end-warehouse` to specify the number of loading warehouses.                                  | 1       |
-| `skip_item_load`       | Whether or not to skip loading item table                                                                                                                             | false   |
+| `skip_item_load`       | Whether or not to skip loading item table.                                                                                                                            | false   |
 | `use_table_index`      | Whether or not to use a generic table-based secondary index instead of ScalarDB's secondary index.                                                                    | false   |
 | `np_only`              | Run benchmark with only new-order and payment transactions (50% each).                                                                                                | false   |
-| `rate_new_order`       | Percentage of new-order transaction. Specify all the rate parameters to use your own mix.                                                                             | N/A     |
-| `rate_payment`         | Percentage of payment transaction. Specify all the rate parameters to use your own mix.                                                                               | N/A     |
-| `rate_order_status`    | Percentage of order-status transaction. Specify all the rate parameters to use your own mix.                                                                          | N/A     |
-| `rate_delivery`        | Percentage of delivery transaction. Specify all the rate parameters to use your own mix.                                                                              | N/A     |
-| `rate_stock_level`     | Percentage of stock-level transaction. Specify all the rate parameters to use your own mix.                                                                           | N/A     |
+| `rate_new_order`       | Percentage of new-order transactions. Specify all the rate parameters to use your own mix.                                                                            | N/A     |
+| `rate_payment`         | Percentage of payment transactions. Specify all the rate parameters to use your own mix.                                                                              | N/A     |
+| `rate_order_status`    | Percentage of order-status transactions. Specify all the rate parameters to use your own mix.                                                                         | N/A     |
+| `rate_delivery`        | Percentage of delivery transactions. Specify all the rate parameters to use your own mix.                                                                             | N/A     |
+| `rate_stock_level`     | Percentage of stock-level transactions. Specify all the rate parameters to use your own mix.                                                                          | N/A     |
 | `backoff`              | Sleep time in milliseconds inserted after a transaction is aborted due to a conflict.                                                                                 | 0       |
 
-### YCSB and multi-storage YCSB
+</div>
+<div id="YCSB_and_multi-storage_YCSB" class="tabcontent" markdown="1">
 
-| name                    | description                                                                       | default                                   |
+| Name                    | Description                                                                       | Default                                   |
 |:------------------------|:----------------------------------------------------------------------------------|:------------------------------------------|
 | `load_concurrency`      | Number of threads for loading.                                                    | 1                                         |
 | `load_batch_size`       | Number of put records in a single loading transaction.                            | 1                                         |
@@ -117,5 +235,6 @@ java -jar scalardb-schema-loader-<version>.jar --config /path/to/scalardb.proper
 | `record_count`          | Number of records in the target table.                                            | 1000                                      |
 | `use_read_modify_write` | Whether or not to use read-modify-writes instead of blind writes in Workload A.   | false[^rmw]                               |
 
-[^rmw]: The default value is `false` for `use_read_modify_write` since Workload A does not assume the transaction reads the original record first.
-However, you need to set `true` if you use the consensus commit for the transaction manager because ScalarDB does not allow a blind write for the existing record.
+[^rmw]: The default value is `false` for `use_read_modify_write` since Workload A doesn't assume that the transaction reads the original record first. However, if you're using Consensus Commit as the transaction manager, you must set `use_read_modify_write` to `true`. This is because ScalarDB doesn't allow a blind write for an existing record.
+</div>
+</div>

--- a/docs/README.md
+++ b/docs/README.md
@@ -111,7 +111,7 @@ The following is an example configuration for running the TPC-C benchmark. The c
 {% capture notice--info %}
 **Note**
 
-Alternatively, instead of specifying each database configuration item in the `.toml` file, you can use the ScalarDB properties file. If `config_file` is specified (commented out below), all other configurations under `database_config` will be ignored.
+Alternatively, instead of using the ScalarDB properties file, you can specify each database configuration item in the `.toml` file. If `config_file` is specified, all other configurations under `database_config` will be ignored even if they are not commented out.
 {% endcapture %}
 
 <div class="notice--info">{{ notice--info | markdownify }}</div>
@@ -129,12 +129,12 @@ name = "com.scalar.db.benchmarks.tpcc.TpccReporter"
 path = "./build/libs/scalardb-benchmarks-all.jar"
 
 [database_config]
-contact_points = "localhost"
-contact_port = 9042
-username = "cassandra"
-password = "cassandra"
-storage = "cassandra"
-#config_file = "<PATH_TO_SCALARDB_PROPERTIES_FILE>"
+config_file = "<PATH_TO_SCALARDB_PROPERTIES_FILE>"
+#contact_points = "localhost"
+#contact_port = 9042
+#username = "cassandra"
+#password = "cassandra"
+#storage = "cassandra"
 ```
 
 You can define parameters to pass to modules in the configuration file. For details, see the sample configuration files below and available parameters in [Common parameters](#common-parameters):
@@ -207,21 +207,21 @@ Select a workload to see its available parameters.
 
 <div id="TPC-C_3" class="tabcontent" markdown="1">
 
-| Name                   | Description                                                                                                                                                           | Default   |
-|:-----------------------|:----------------------------------------------------------------------------------------------------------------------------------------------------------------------|:----------|
-| `num_warehouses`       | Number of warehouses (scale factor) for benchmarking.                                                                                                                 | `1`       |
-| `load_concurrency`     | Number of threads for loading.                                                                                                                                        | `1`       |
-| `load_start_warehouse` | Start ID of loading warehouse. This option can be useful with `--skip-item-load` when loading large-scale data with multiple clients or adding additional warehouses. | `1`       |
-| `load_end_warehouse`   | End ID of loading warehouse. You can use either `--num-warehouses` or `--end-warehouse` to specify the number of loading warehouses.                                  | `1`       |
-| `skip_item_load`       | Whether or not to skip loading item table.                                                                                                                            | `false`   |
-| `use_table_index`      | Whether or not to use a generic table-based secondary index instead of ScalarDB's secondary index.                                                                    | `false`   |
-| `np_only`              | Run benchmark with only new-order and payment transactions (50% each).                                                                                                | `false`   |
-| `rate_new_order`       | Percentage of new-order transactions. Specify all the rate parameters to use your own mix.                                                                            | N/A       |
-| `rate_payment`         | Percentage of payment transactions. Specify all the rate parameters to use your own mix.                                                                              | N/A       |
-| `rate_order_status`    | Percentage of order-status transactions. Specify all the rate parameters to use your own mix.                                                                         | N/A       |
-| `rate_delivery`        | Percentage of delivery transactions. Specify all the rate parameters to use your own mix.                                                                             | N/A       |
-| `rate_stock_level`     | Percentage of stock-level transactions. Specify all the rate parameters to use your own mix.                                                                          | N/A       |
-| `backoff`              | Sleep time in milliseconds inserted after a transaction is aborted due to a conflict.                                                                                 | `0`       |
+| Name                   | Description                                                                                                                                                                                                                          | Default   |
+|:-----------------------|:-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:----------|
+| `num_warehouses`       | Number of warehouses (scale factor) for benchmarking.                                                                                                                                                                                | `1`       |
+| `load_concurrency`     | Number of threads for loading.                                                                                                                                                                                                       | `1`       |
+| `load_start_warehouse` | Start ID of loading warehouse. This option can be useful with `--skip-item-load` when loading large-scale data with multiple clients or adding additional warehouses.                                                                | `1`       |
+| `load_end_warehouse`   | End ID of loading warehouse. You can use either `--num-warehouses` or `--end-warehouse` to specify the number of loading warehouses.                                                                                                 | `1`       |
+| `skip_item_load`       | Whether or not to skip loading item table.                                                                                                                                                                                           | `false`   |
+| `use_table_index`      | Whether or not to use a generic table-based secondary index instead of ScalarDB's secondary index.                                                                                                                                   | `false`   |
+| `np_only`              | Run benchmark with only new-order and payment transactions (50% each).                                                                                                                                                               | `false`   |
+| `rate_new_order`       | Percentage of new-order transactions. When specifying this percentage based on your needs, you must specify the percentages for all other rate parameters. In that case, the total of all rate parameters must equal 100 percent.    | N/A       |
+| `rate_payment`         | Percentage of payment transactions. When specifying this percentage based on your needs, you must specify the percentages for all other rate parameters. In that case, the total of all rate parameters must equal 100 percent.      | N/A       |
+| `rate_order_status`    | Percentage of order-status transactions. When specifying this percentage based on your needs, you must specify the percentages for all other rate parameters. In that case, the total of all rate parameters must equal 100 percent. | N/A       |
+| `rate_delivery`        | Percentage of delivery transactions. When specifying this percentage based on your needs, you must specify the percentages for all other rate parameters. In that case, the total of all rate parameters must equal 100 percent.     | N/A       |
+| `rate_stock_level`     | Percentage of stock-level transactions. When specifying this percentage based on your needs, you must specify the percentages for all other rate parameters. In that case, the total of all rate parameters must equal 100 percent.  | N/A       |
+| `backoff`              | Sleep time in milliseconds inserted after a transaction is aborted due to a conflict.                                                                                                                                                | `0`       |
 
 </div>
 <div id="YCSB_and_multi-storage_YCSB" class="tabcontent" markdown="1">
@@ -231,7 +231,7 @@ Select a workload to see its available parameters.
 | `load_concurrency`      | Number of threads for loading.                                                    | `1`                                           |
 | `load_batch_size`       | Number of put records in a single loading transaction.                            | `1`                                           |
 | `load_overwrite`        | Whether or not to overwrite when loading records.                                 | `false`                                       |
-| `ops_per_tx`            | Number of operations in a single transaction.                                     | `2` (Workloads A and C) <br> `1` (Workload F)  |
+| `ops_per_tx`            | Number of operations in a single transaction.                                     | `2` (Workloads A and C) <br> `1` (Workload F) |
 | `record_count`          | Number of records in the target table.                                            | `1000`                                        |
 | `use_read_modify_write` | Whether or not to use read-modify-writes instead of blind writes in Workload A.   | `false`[^rmw]                                 |
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 
 This tutorial describes how to set up and run benchmarking tools for ScalarDB.
 
-## Available workloads
+## Available benchmark workloads
 
 - TPC-C
 - YCSB (Workloads A, C, and F)
@@ -61,7 +61,7 @@ To build the benchmarking tools, run the following command:
 $ ./gradlew shadowJar
 ```
 
-### Create tables
+### Load the schema
 
 Before loading the initial data, the tables must be defined by using the [ScalarDB Schema Loader](https://github.com/scalar-labs/scalardb/blob/master/docs/schema-loader.md). To apply the schema, go to the [ScalarDB Releases](https://github.com/scalar-labs/scalardb/releases) page and download the ScalarDB Schema Loader that matches the version of ScalarDB that you are using to the `scalardb-benchmarks` root folder.
 
@@ -81,7 +81,7 @@ After applying the schema and configuring the properties file, select a benchmar
 To create tables for TPC-C benchmarking ([`tpcc-schema.json`](https://github.com/scalar-labs/scalardb-benchmarks/blob/master/tpcc-schema.json)), run the following command, replacing the contents in the angle brackets as described:
 
 ```console
-$ java -jar scalardb-schema-loader-<VERSION>.jar --config /<PATH_TO>/scalardb.properties -f tpcc-schema.json --coordinator
+$ java -jar scalardb-schema-loader-<VERSION>.jar --config <PATH_TO_SCALARDB_PROPERTIES_FILE> -f tpcc-schema.json --coordinator
 ```
 </div>
 <div id="YCSB_1" class="tabcontent" markdown="1">
@@ -89,7 +89,7 @@ $ java -jar scalardb-schema-loader-<VERSION>.jar --config /<PATH_TO>/scalardb.pr
 To create tables for YCSB benchmarking ([`ycsb-schema.json`](https://github.com/scalar-labs/scalardb-benchmarks/blob/master/ycsb-schema.json)), run the following command, replacing the contents in the angle brackets as described:
 
 ```console
-$ java -jar scalardb-schema-loader-<VERSION>.jar --config /<PATH_TO>/scalardb.properties -f ycsb-schema.json --coordinator
+$ java -jar scalardb-schema-loader-<VERSION>.jar --config <PATH_TO_SCALARDB_PROPERTIES_FILE> -f ycsb-schema.json --coordinator
 ```
 </div>
 <div id="multi-storage_YCSB_1" class="tabcontent" markdown="1">
@@ -97,7 +97,7 @@ $ java -jar scalardb-schema-loader-<VERSION>.jar --config /<PATH_TO>/scalardb.pr
 To create tables for multi-storage YCSB benchmarking ([`ycsb-multi-storage-schema.json`](https://github.com/scalar-labs/scalardb-benchmarks/blob/master/ycsb-multi-storage-schema.json)), run the following command, replacing the contents in the angle brackets as described:
 
 ```console
-$ java -jar scalardb-schema-loader-<VERSION>.jar --config /<PATH_TO>/scalardb.properties -f ycsb-multi-storage-schema.json --coordinator
+$ java -jar scalardb-schema-loader-<VERSION>.jar --config <PATH_TO_SCALARDB_PROPERTIES_FILE> -f ycsb-multi-storage-schema.json --coordinator
 ```
 </div>
 </div>
@@ -134,10 +134,10 @@ contact_port = 9042
 username = "cassandra"
 password = "cassandra"
 storage = "cassandra"
-#config_file = "/<PATH_TO>/scalardb.properties"
+#config_file = "<PATH_TO_SCALARDB_PROPERTIES_FILE>"
 ```
 
-You can define static parameters to pass to modules in the configuration file. For details, see the sample configuration files below and available parameters in [Common parameters](#common-parameters):
+You can define parameters to pass to modules in the configuration file. For details, see the sample configuration files below and available parameters in [Common parameters](#common-parameters):
 
 - **TPC-C:** [`tpcc-benchmark-config.toml`](https://github.com/scalar-labs/scalardb-benchmarks/blob/master/tpcc-benchmark-config.toml)
 - **YCSB:** [`ycsb-benchmark-config.toml`](https://github.com/scalar-labs/scalardb-benchmarks/blob/master/ycsb-benchmark-config.toml)

--- a/docs/README.md
+++ b/docs/README.md
@@ -106,12 +106,12 @@ $ java -jar scalardb-schema-loader-<VERSION>.jar --config <PATH_TO_SCALARDB_PROP
 
 To run a benchmark, you must first prepare a benchmarking configuration file. The configuration file requires at least the locations of the workload modules to run and the database configuration. 
 
-The following is an example configuration for running the TPC-C benchmark. The configurations under `database_config` should match the [benchmarking environment that you previously set up](#set-up-your-environment).
+The following is an example configuration for running the TPC-C benchmark. The ScalarDB properties file specified for `config_file` should be the properties file for the [benchmarking environment that you previously set up](#set-up-your-environment).
 
 {% capture notice--info %}
 **Note**
 
-Alternatively, instead of using the ScalarDB properties file, you can specify each database configuration item in the `.toml` file. If `config_file` is specified, all other configurations under `database_config` will be ignored even if they are not commented out.
+Alternatively, instead of using the ScalarDB properties file, you can specify each database configuration item in the `.toml` file. If `config_file` is specified, all other configurations under `[database_config]` will be ignored even if they are uncommented.
 {% endcapture %}
 
 <div class="notice--info">{{ notice--info | markdownify }}</div>

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,7 +5,7 @@ This tutorial describes how to set up and run benchmarking tools for ScalarDB.
 ## Available workloads
 
 - TPC-C
-- Yahoo! Cloud Serving Benchmark (YCSB) (Workloads A, C, and F)
+- YCSB (Workloads A, C, and F)
 - Multi-storage YCSB (Workloads C and F)
   - This YCSB variant is for a multi-storage environment that uses ScalarDB.
   - Workers in a multi-storage YCSB execute the same number of read and write operations in two namespaces: `ycsb_primary` and `ycsb_secondary`.

--- a/tpcc-benchmark-config.toml
+++ b/tpcc-benchmark-config.toml
@@ -29,12 +29,12 @@ num_warehouses = 1
 #rate_stock_level = 4
 
 [database_config]
-contact_points = "localhost"
-contact_port = 9042
-username = "cassandra"
-password = "cassandra"
-storage = "cassandra"
-transaction_manager = "consensus-commit"
-isolation_level = "SNAPSHOT"
-serializable_strategy = "EXTRA_READ"
-#config_file = "/path/to/scalardb.properties"
+config_file = "<PATH_TO_SCALARDB_PROPERTIES_FILE>"
+#contact_points = "localhost"
+#contact_port = 9042
+#username = "cassandra"
+#password = "cassandra"
+#storage = "cassandra"
+#transaction_manager = "consensus-commit"
+#isolation_level = "SNAPSHOT"
+#serializable_strategy = "EXTRA_READ"

--- a/ycsb-benchmark-config.toml
+++ b/ycsb-benchmark-config.toml
@@ -26,12 +26,12 @@ load_concurrency = 4
 #use_read_modify_write = true
 
 [database_config]
-contact_points = "jdbc:mysql://localhost/"
+config_file = "<PATH_TO_SCALARDB_PROPERTIES_FILE>"
+#contact_points = "jdbc:mysql://localhost/"
 #contact_port =
-username = "root"
-password = "mysql"
-storage = "jdbc"
-transaction_manager = "consensus-commit"
-isolation_level = "SERIALIZABLE"
-serializable_strategy = "EXTRA_READ"
-#config_file = "/path/to/scalardb.properties"
+#username = "root"
+#password = "mysql"
+#storage = "jdbc"
+#transaction_manager = "consensus-commit"
+#isolation_level = "SERIALIZABLE"
+#serializable_strategy = "EXTRA_READ"

--- a/ycsb-multi-storage-benchmark-config.toml
+++ b/ycsb-multi-storage-benchmark-config.toml
@@ -25,4 +25,4 @@ load_concurrency = 4
 #load_overwrite = true
 
 [database_config]
-config_file = "/path/to/multi-storage-scalardb.properties"
+config_file = "<PATH_TO_SCALARDB_PROPERTIES_FILE>"


### PR DESCRIPTION
## Description

This PR revises the ScalarDB benchmarks document.

## Related issues and/or PRs

N/A

## Changes made

- Revised contents.
- Added notice blocks for noteworthy content.
- Added content tabs for benchmarking tools.

The following is a screenshot of this doc on the docs site (locally).

![scalardb-benchmarks_README](https://github.com/scalar-labs/scalardb-benchmarks/assets/23216828/b7adec49-ca2c-46e3-b0c1-094ad7f43b29)

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

Please see comments in the document.

## Release notes

N/A
