### PR TITLE
Use the latest ScalarDB

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ ext {
     kelpieVersion = '1.2.3'
     resilience4jRetryVersion = '1.7.1'
     slf4jVersion = '1.7.25'
-    scalarDbVersion = '3.7.2'
+    scalarDbVersion = '3.12.2'
 }
 
 dependencies {

--- a/src/main/java/com/scalar/db/benchmarks/tpcc/transaction/DeliveryTransaction.java
+++ b/src/main/java/com/scalar/db/benchmarks/tpcc/transaction/DeliveryTransaction.java
@@ -44,7 +44,7 @@ public class DeliveryTransaction implements TpccTransaction {
       // Get the oldest outstanding new-order
       List<Result> newOrders = transaction.scan(NewOrder.createScan(warehouseId, districtId));
       if (newOrders.size() != 1) {
-        throw new TransactionException("Invalid scan on new-order");
+        throw new TransactionException("Invalid scan on new-order", transaction.getId());
       }
       int orderId = newOrders.get(0).getValue(NewOrder.KEY_ORDER_ID).get().getAsInt();
 
@@ -54,7 +54,7 @@ public class DeliveryTransaction implements TpccTransaction {
       // Get the customer of the new-order
       Optional<Result> result = transaction.get(Order.createGet(warehouseId, districtId, orderId));
       if (!result.isPresent()) {
-        throw new TransactionException("Order not found");
+        throw new TransactionException("Order not found", transaction.getId());
       }
       int customerId = result.get().getValue(Order.KEY_CUSTOMER_ID).get().getAsInt();
 
@@ -76,7 +76,7 @@ public class DeliveryTransaction implements TpccTransaction {
       // Update the customer with new balance and delivery count
       result = transaction.get(Customer.createGet(warehouseId, districtId, customerId));
       if (!result.isPresent()) {
-        throw new TransactionException("Customer not found");
+        throw new TransactionException("Customer not found", transaction.getId());
       }
       double balance = result.get().getValue(Customer.KEY_BALANCE).get().getAsDouble() + total;
       int deliveryCount = result.get().getValue(Customer.KEY_DELIVERY_CNT).get().getAsInt() + 1;

--- a/src/main/java/com/scalar/db/benchmarks/tpcc/transaction/OrderStatusTransaction.java
+++ b/src/main/java/com/scalar/db/benchmarks/tpcc/transaction/OrderStatusTransaction.java
@@ -34,7 +34,7 @@ public class OrderStatusTransaction implements TpccTransaction {
   private int getOrderIdBySecondaryIndex(DistributedTransaction tx) throws TransactionException {
     List<Result> results = tx.scan(Order.createScan(warehouseId, districtId, customerId));
     if (results.size() < 1) {
-      throw new TransactionException("Invalid scan on order-secondary");
+      throw new TransactionException("Invalid scan on order-secondary", tx.getId());
     }
     results.sort(Order.ORDER_ID_COMPARATOR);
     return results.get(0).getValue(Order.KEY_ID).get().getAsInt();
@@ -43,7 +43,7 @@ public class OrderStatusTransaction implements TpccTransaction {
   private int getOrderIdByTableIndex(DistributedTransaction tx) throws TransactionException {
     List<Result> results = tx.scan(OrderSecondary.createScan(warehouseId, districtId, customerId));
     if (results.size() != 1) {
-      throw new TransactionException("Invalid scan on order-secondary");
+      throw new TransactionException("Invalid scan on order-secondary", tx.getId());
     }
     return results.get(0).getValue(OrderSecondary.KEY_ORDER_ID).get().getAsInt();
   }
@@ -79,7 +79,7 @@ public class OrderStatusTransaction implements TpccTransaction {
     Optional<Result> result =
         transaction.get(Customer.createGet(warehouseId, districtId, customerId));
     if (!result.isPresent()) {
-      throw new TransactionException("Customer not found");
+      throw new TransactionException("Customer not found", transaction.getId());
     }
 
     // Find the last order of the customer
@@ -93,7 +93,7 @@ public class OrderStatusTransaction implements TpccTransaction {
     // Get order
     result = transaction.get(Order.createGet(warehouseId, districtId, orderId));
     if (!result.isPresent()) {
-      throw new TransactionException("Order not found");
+      throw new TransactionException("Order not found", transaction.getId());
     }
 
     // Get order-line

--- a/src/main/java/com/scalar/db/benchmarks/tpcc/transaction/PaymentTransaction.java
+++ b/src/main/java/com/scalar/db/benchmarks/tpcc/transaction/PaymentTransaction.java
@@ -114,7 +114,7 @@ public class PaymentTransaction implements TpccTransaction {
     // Get and update warehouse
     Optional<Result> result = transaction.get(Warehouse.createGet(warehouseId));
     if (!result.isPresent()) {
-      throw new TransactionException("Warehouse not found");
+      throw new TransactionException("Warehouse not found", transaction.getId());
     }
     final String warehouseName =
         result.get().getValue(Warehouse.KEY_NAME).get().getAsString().get();
@@ -126,7 +126,7 @@ public class PaymentTransaction implements TpccTransaction {
     // Get and update district
     result = transaction.get(District.createGet(warehouseId, districtId));
     if (!result.isPresent()) {
-      throw new TransactionException("District not found");
+      throw new TransactionException("District not found", transaction.getId());
     }
     final String districtName = result.get().getValue(District.KEY_NAME).get().getAsString().get();
     final double districtYtd =
@@ -149,7 +149,7 @@ public class PaymentTransaction implements TpccTransaction {
     result =
         transaction.get(Customer.createGet(customerWarehouseId, customerDistrictId, customerId));
     if (!result.isPresent()) {
-      throw new TransactionException("Customer not found");
+      throw new TransactionException("Customer not found", transaction.getId());
     }
     final double balance =
         result.get().getValue(Customer.KEY_BALANCE).get().getAsDouble() + paymentAmount;

--- a/src/main/java/com/scalar/db/benchmarks/tpcc/transaction/StockLevelTransaction.java
+++ b/src/main/java/com/scalar/db/benchmarks/tpcc/transaction/StockLevelTransaction.java
@@ -45,7 +45,7 @@ public class StockLevelTransaction implements TpccTransaction {
     // Get next order ID in the district
     Optional<Result> result = transaction.get(District.createGet(warehouseId, districtId));
     if (!result.isPresent()) {
-      throw new TransactionException("District not found");
+      throw new TransactionException("District not found", transaction.getId());
     }
     int orderId = result.get().getValue(District.KEY_NEXT_O_ID).get().getAsInt();
 
@@ -69,7 +69,7 @@ public class StockLevelTransaction implements TpccTransaction {
     for (int itemId : itemSet) {
       Optional<Result> stock = transaction.get(Stock.createGet(warehouseId, itemId));
       if (!stock.isPresent()) {
-        throw new TransactionException("Stock not found");
+        throw new TransactionException("Stock not found", transaction.getId());
       }
       int quantity = stock.get().getValue(Stock.KEY_QUANTITY).get().getAsInt();
       if (quantity < threshold) {


### PR DESCRIPTION
## Description

The current version of ScalarDB Benchmarks uses ScalarDB `3.7.2`. It's a bit too old. This PR upgrades the version and fixes some compile errors.

## Related issues and/or PRs

None

## Changes made

- Upgrade ScalarDB version from `3.7.2` to `3.12.2`
- `com.scalar.db.exception.transaction.TransactionException` constructor was updated to require `String transactionId` parameter between `3.7.2` and `3.12.2`. To fix compile errors from that, pass the transaction ID to the constructer

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [ ] Tests (unit, integration, etc.) have been added for the changes.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

None

## Release notes

N/A