### PR TITLE
Change default behavior of YCSB Workload A

### DIFF
--- a/src/main/java/com/scalar/db/benchmarks/ycsb/WorkloadA.java
+++ b/src/main/java/com/scalar/db/benchmarks/ycsb/WorkloadA.java
@@ -23,7 +23,10 @@ import javax.json.Json;
 
 /**
  * Workload A: Update heavy workload. This workload has a mix of 50/50 reads and writes. The writes
- * can be changed to read-modify-write if "use_read_modify_write" is set to true.
+ * in the original Workload A are blind writes. However, ScalarDB doesn't allow a blind write for an
+ * existing record when you're using the default transaction manager, Consensus Commit. So, we use
+ * read-modify-write operations instead. You can change them to the blind writes by setting
+ * "use_read_modify_write" to false.
  */
 public class WorkloadA extends TimeBasedProcessor {
   private static final long DEFAULT_OPS_PER_TX = 2; // one read operation and one write operation

--- a/src/main/java/com/scalar/db/benchmarks/ycsb/WorkloadA.java
+++ b/src/main/java/com/scalar/db/benchmarks/ycsb/WorkloadA.java
@@ -45,7 +45,7 @@ public class WorkloadA extends TimeBasedProcessor {
     if (opsPerTx % 2 != 0) {
       throw new IllegalArgumentException(OPS_PER_TX + " must be a multiple of 2.");
     }
-    useReadModifyWrite = config.getUserBoolean(CONFIG_NAME, USE_READ_MODIFY_WRITE, false);
+    useReadModifyWrite = config.getUserBoolean(CONFIG_NAME, USE_READ_MODIFY_WRITE, true);
   }
 
   @Override


### PR DESCRIPTION
## Description

This PR changes the default behavior of YCSB Workload A. Since the default transaction manager of ScalarDB, consensus commit, does not allow blind writes, the default value of the `use_read_modify_write ` option should be true.

## Related issues and/or PRs

- https://github.com/scalar-labs/docs-internal-scalardb/pull/1701/files#r2517674120

## Changes made

- Change the default value of the `use_read_modify_write` option to true

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [ ] Tests (unit, integration, etc.) have been added for the changes.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A
