### PR TITLE
Add the zip64 option to the shadowJar task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ dependencies {
 
 shadowJar {
     mergeServiceFiles()
+    zip64 = true
 }
 
 sourceCompatibility = 1.8


### PR DESCRIPTION
## Description

This PR adds the zip64 option for the shadowJar task since creating a shadow jar fails.

## Related issues and/or PRs

N/A

## Changes made

- Added the zip64 option to the shadowJar task
- 
## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [ ] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

Added zip64 option to fix the build failure for creating a shadow jar.
