### PR TITLE
Update README file

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -19,7 +19,7 @@ This tutorial describes how to run benchmarking tools for ScalarDB. Database ben
 ## Prerequisites
 
 - Java Development Kit (JDK):
-  - Supported versions: 8, 11, 17, and 21
+  - OpenJDK LTS version (8, 11, 17, or 21) from [Eclipse Temurin](https://adoptium.net/temurin/releases/)
 - Gradle
 - [Kelpie](https://github.com/scalar-labs/kelpie)
   - Kelpie is a framework for performing end-to-end testing, such as system benchmarking and verification. Get the latest version from [Kelpie Releases](https://github.com/scalar-labs/kelpie), and unzip the archive file.

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,7 +25,7 @@ This tutorial describes how to run benchmarking tools for ScalarDB. Database ben
   - Kelpie is a framework for performing end-to-end testing, such as system benchmarking and verification. Get the latest version from [Kelpie Releases](https://github.com/scalar-labs/kelpie), and unzip the archive file.
 - A client to run the benchmarking tools
 - A target database
-  - For a list of databases that ScalarDB supports, see [Supported Databases](https://github.com/scalar-labs/docs-internal-scalardb/blob/main/docs/en-us/requirements.mdx#databases).
+  - For a list of databases that ScalarDB supports, see [Supported Databases](https://scalardb.scalar-labs.com/docs/latest/requirements/#databases).
 
 
 ## Set up the benchmarking tools

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,13 +27,6 @@ This tutorial describes how to run benchmarking tools for ScalarDB. Database ben
 - A target database
   - For a list of databases that ScalarDB supports, see [Supported Databases](https://github.com/scalar-labs/scalardb/blob/master/docs/scalardb-supported-databases.md).
 
-{% capture notice--info %}
-**Note**
-
-Currently, only JDK 8 can be used when running the benchmarking tools.
-{% endcapture %}
-
-<div class="notice--info">{{ notice--info | markdownify }}</div>
 
 ## Set up the benchmarking tools
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,7 +25,7 @@ This tutorial describes how to run benchmarking tools for ScalarDB. Database ben
   - Kelpie is a framework for performing end-to-end testing, such as system benchmarking and verification. Get the latest version from [Kelpie Releases](https://github.com/scalar-labs/kelpie), and unzip the archive file.
 - A client to run the benchmarking tools
 - A target database
-  - For a list of databases that ScalarDB supports, see [Supported Databases](https://github.com/scalar-labs/scalardb/blob/master/docs/scalardb-supported-databases.md).
+  - For a list of databases that ScalarDB supports, see [Supported Databases](https://github.com/scalar-labs/docs-internal-scalardb/blob/main/docs/en-us/requirements.mdx#databases).
 
 
 ## Set up the benchmarking tools

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,9 +18,8 @@ This tutorial describes how to run benchmarking tools for ScalarDB. Database ben
 
 ## Prerequisites
 
-- One of the following Java Development Kits (JDKs):
-  - [Oracle JDK](https://www.oracle.com/java/technologies/downloads/) LTS version 8
-  - [OpenJDK](https://openjdk.org/install/) LTS version 8
+- Java Development Kit (JDK):
+  - Supported versions: 8, 11, 17, and 21
 - Gradle
 - [Kelpie](https://github.com/scalar-labs/kelpie)
   - Kelpie is a framework for performing end-to-end testing, such as system benchmarking and verification. Get the latest version from [Kelpie Releases](https://github.com/scalar-labs/kelpie), and unzip the archive file.

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,7 +22,8 @@ The following Java Development Kits (JDKs) are verified and supported:
 
 - The following Java Development Kits (JDKs) are verified and supported:
   - **[Oracle JDK](https://www.oracle.com/java/):** 8, 11, 17, or 21 (LTS versions)
-  - **[OpenJDK](https://openjdk.org/) ([Eclipse Temurin](https://adoptium.net/temurin/), [Amazon Corretto](https://aws.amazon.com/corretto/), or [Microsoft Build of OpenJDK](https://learn.microsoft.com/en-us/java/openjdk/)):** 8, 11, 17, or 21 (LTS versions)
+  - **OpenJDK ([Eclipse Temurin](https://adoptium.net/temurin/), [Amazon Corretto](https://aws.amazon.com/corretto/), or [Microsoft Build of OpenJDK](https://learn.microsoft.com/en-us/java/openjdk/)):** 8, 11, 17, or 21 (LTS versions)
+
 
 - Gradle
 - [Kelpie](https://github.com/scalar-labs/kelpie)

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,9 +22,7 @@ The following Java Development Kits (JDKs) are verified and supported:
 
 - The following Java Development Kits (JDKs) are verified and supported:
   - **[Oracle JDK](https://www.oracle.com/java/):** 8, 11, 17, or 21 (LTS versions)
-  - **OpenJDK ([Eclipse Temurin](https://adoptium.net/temurin/), [Amazon Corretto](https://aws.amazon.com/corretto/), or [Microsoft Build of OpenJDK](https://learn.microsoft.com/en-us/java/openjdk/)):** 8, 11, 17, or 21 (LTS versions)
-
-
+  - **OpenJDK distribution ([Eclipse Temurin](https://adoptium.net/temurin/), [Amazon Corretto](https://aws.amazon.com/corretto/), or [Microsoft Build of OpenJDK](https://learn.microsoft.com/en-us/java/openjdk/)):** 8, 11, 17, or 21 (LTS versions)
 - Gradle
 - [Kelpie](https://github.com/scalar-labs/kelpie)
   - Kelpie is a framework for performing end-to-end testing, such as system benchmarking and verification. Get the latest version from [Kelpie Releases](https://github.com/scalar-labs/kelpie), and unzip the archive file.

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,8 +18,12 @@ This tutorial describes how to run benchmarking tools for ScalarDB. Database ben
 
 ## Prerequisites
 
-- Java Development Kit (JDK):
-  - OpenJDK LTS version (8, 11, 17, or 21) from [Eclipse Temurin](https://adoptium.net/temurin/releases/)
+The following Java Development Kits (JDKs) are verified and supported:
+
+- The following Java Development Kits (JDKs) are verified and supported:
+  - **[Oracle JDK](https://www.oracle.com/java/):** 8, 11, 17, or 21 (LTS versions)
+  - **[OpenJDK](https://openjdk.org/) ([Eclipse Temurin](https://adoptium.net/temurin/), [Amazon Corretto](https://aws.amazon.com/corretto/), or [Microsoft Build of OpenJDK](https://learn.microsoft.com/en-us/java/openjdk/)):** 8, 11, 17, or 21 (LTS versions)
+
 - Gradle
 - [Kelpie](https://github.com/scalar-labs/kelpie)
   - Kelpie is a framework for performing end-to-end testing, such as system benchmarking and verification. Get the latest version from [Kelpie Releases](https://github.com/scalar-labs/kelpie), and unzip the archive file.


### PR DESCRIPTION
## Description

In this PR, I have updated the README file to indicate that the tests can be run with Java version 8, 11, 17 and 21.
I am aware that this document is moved to `https://github.com/scalar-labs/docs-internal-scalardb` but updating it here first. 
I will check and add the changes for the same document (English  version in https://github.com/scalar-labs/docs-internal-scalardb) once the changes are approved here.

## Related issues and/or PRs

NA

## Changes made

In README file

* I have updated the prerequisites - Removed Java 8 specified JDKs and update that it can be run with any of the JDKs 8, 11, 17 and 21.

* I have removed the note indicating that Java 8 is required.
* I have updated the broken link for scalardb supported databases (I have added the link to English version in the internal documents as the current document is in English version).

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [ ] Tests (unit, integration, etc.) have been added for the changes.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

NA

## Release notes

README file updated
